### PR TITLE
Fix signature check bypass

### DIFF
--- a/pymavlink/generator/C/include_v2.0/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v2.0/mavlink_helpers.h
@@ -99,13 +99,17 @@ MAVLINK_HELPER bool mavlink_signature_check(mavlink_signing_t *signing,
 		return true;
 	}
         const uint8_t *p = (const uint8_t *)&msg->magic;
-        uint16_t len = MAVLINK_CORE_HEADER_LEN+1+msg->len+2+1+6;
+        uint32_t len = MAVLINK_CORE_HEADER_LEN+1+msg->len+2+1+6;
 	const uint8_t *psig = p + MAVLINK_CORE_HEADER_LEN+1+msg->len+2;
         const uint8_t *incoming_signature = psig+7;
 	mavlink_sha256_ctx ctx;
 	uint8_t signature[6];
 	uint16_t i;
-        
+
+        if (len > UINT16_MAX) {
+                return false;
+        }
+
 	mavlink_sha256_init(&ctx);
 	mavlink_sha256_update(&ctx, signing->secret_key, sizeof(signing->secret_key));
 	mavlink_sha256_update(&ctx, p, len);


### PR DESCRIPTION
Signature check could be bypassed if `msg->len` is just right to overflow
the calculation of len.  Since the len variable is an uint16_t, it could wrap
to 0, which disregards the contents of the message for signature checking
purposes.

Fix by declaring len as an uint32_t and returning false if it exceeds
an UINT16_MAX.

Found via code inspection.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>