### PR TITLE
Added support for MAV_CMD_NAV_DELAY in common.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -772,6 +772,16 @@
                     <param index="6">Empty</param>
                     <param index="7">Empty</param>
                </entry>
+               <entry value="94" name="MAV_CMD_NAV_DELAY">
+                    <description>Delay the next navigation command</description>
+                    <param index="1">Delay in seconds (decimal)</param>
+                    <param index="2">absolute time's hour (UTC)</param>
+                    <param index="3">absolute time's minutes (UTC)</param>
+                    <param index="4">absolute time's seconds (UTC)</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
                <entry value="95" name="MAV_CMD_NAV_LAST">
                     <description>NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration</description>
                     <param index="1">Empty</param>


### PR DESCRIPTION
A new mavlink command is created for https://github.com/ArduPilot/ardupilot/issues/939. This command will accept the delay time in seconds and UTC to delay the execution of next navigation command in mission.