### PR TITLE
Adding the MAV_GPS type

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3342,7 +3342,7 @@
             <field type="int16_t" name="vn">GPS velocity in cm/s in NORTH direction in earth-fixed NED frame</field>
             <field type="int16_t" name="ve">GPS velocity in cm/s in EAST direction in earth-fixed NED frame</field>
             <field type="int16_t" name="vd">GPS velocity in cm/s in DOWN direction in earth-fixed NED frame</field>
-            <field type="uint16_t" name="cog">Course over ground in centidegrees, 0.0..359.99 degrees.</field>
+            <field type="uint16_t" name="cog">Course over ground in centidegrees, 0..35999.</field>
             <field type="int32_t" name="sog">Speed over ground in cm/s</field>
             <field type="int32_t" name="speed_accuracy">GPS speed accuracy in cm/s</field>
             <field type="int32_t" name="horiz_accuracy">GPS horizontal accuracy in cm</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3328,6 +3328,27 @@
             <field name="horiz_accuracy" type="float">Horizontal speed 1-STD accuracy</field>
             <field name="vert_accuracy" type="float">Vertical speed 1-STD accuracy</field>
         </message>
+        <message id="232" name="MAV_GPS">
+            <description>GPS sensor input message for the AP_GPS_MAV type</description>
+            <field type="uint16_t" name="ignore">Flags indicating which fields to ignore: bit0:alt, bit1:hdop, bit2:vdop, bit3:vel(vn+ve+vd), bit4:cog, bit5:sog, bit6:speed_accuracy, bit7:horiz_accuracy, bit8:vert_accuracy. All other fields must be provided.</field>
+            <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
+            <field type="uint16_t" name="time_week">GPS week number</field>
+            <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
+            <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+            <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+            <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in cm (positive for up)</field>
+            <field type="uint16_t" name="hdop">GPS HDOP horizontal dilution of position in cm</field>
+            <field type="uint16_t" name="vdop">GPS VDOP vertical dilution of position in cm</field>
+            <field type="int16_t" name="vn">GPS velocity in cm/s in NORTH direction in earth-fixed NED frame</field>
+            <field type="int16_t" name="ve">GPS velocity in cm/s in EAST direction in earth-fixed NED frame</field>
+            <field type="int16_t" name="vd">GPS velocity in cm/s in DOWN direction in earth-fixed NED frame</field>
+            <field type="uint16_t" name="cog">Course over ground in centidegrees, 0.0..359.99 degrees.</field>
+            <field type="int32_t" name="sog">Speed over ground in cm/s</field>
+            <field type="int32_t" name="speed_accuracy">GPS speed accuracy in cm/s</field>
+            <field type="int32_t" name="horiz_accuracy">GPS horizontal accuracy in cm</field>
+            <field type="int32_t" name="vert_accuracy">GPS vertical accuracy in cm</field>
+            <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
+        </message>
         <message id="241" name="VIBRATION">
             <description>Vibration levels and accelerometer clipping</description>
             <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>


### PR DESCRIPTION
This allows GCSs to provide GPS data to the autopilot.  The MAV_GPS message is very similar to the HIL_GPS message, however more care is taken to specify GPS time.  Additionally, a bitfield is used to specify which fields are valid in the message.