### PR TITLE
Adding a message to run the pre arm checks

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -139,6 +139,17 @@
                 <param index="7">Empty</param>
             </entry>
 
+            <entry name="MAV_CMD_DO_ARM_CHECK" value="42429">
+                <description>Reply with whether or not you can arm and why</description>
+                <param index="1">Empty</param>
+                <param index="2">Empty</param>
+                <param index="3">Empty</param>
+                <param index="4">Empty</param>
+                <param index="5">Empty</param>
+                <param index="6">Empty</param>
+                <param index="7">Empty</param>
+            </entry>
+
             <entry name="MAV_CMD_GIMBAL_RESET" value="42501">
                 <description>Causes the gimbal to reset and boot as if it was just powered on</description>
                 <param index="1">Empty</param>


### PR DESCRIPTION
We need the ability to run pre-arm checks on demand without actually arming (at a faster rate than the 1Hz we currently have). I have a corresponding commit for the flight code I can make a PR for if upstream wants to include this message.
