### PR TITLE
pymavlink: add GUIDED_NOGPS flight mode

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -1428,6 +1428,7 @@ mode_mapping_acm = {
     17 : 'BRAKE',
     18 : 'THROW',
     19 : 'AVOID_ADSB',
+    20 : 'GUIDED_NOGPS',
     }
 mode_mapping_rover = {
     0 : 'MANUAL',


### PR DESCRIPTION
This adds a recently added flight mode for use with copter

The equivalent upstream PR is here: https://github.com/mavlink/mavlink/pull/609
