### PR TITLE
Add To define the bit number for GPS_INPUT_IGNORE_FLAGS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2188,6 +2188,32 @@
           </enum>
 
           <!-- GPS_INPUT ignore flags enum -->
+          <enum name="GPS_INPUT_IGNORE_FLAGS_BIT">
+              <entry name="GPS_INPUT_IGNORE_FLAG_ALT_BIT" value="0">
+                  <description>ignore altitude field bit#</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_HDOP_BIT" value="1">
+                  <description>ignore hdop field bit#</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_VDOP_BIT" value="2">
+                  <description>ignore vdop field bit#</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_VEL_HORIZ_BIT" value="3">
+                  <description>ignore horizontal velocity field (vn and ve) bit#</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_VEL_VERT_BIT" value="4">
+                  <description>ignore vertical velocity field (vd) bit#</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY_BIT" value="5">
+                  <description>ignore speed accuracy field bit#</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY_BIT" value="6">
+                  <description>ignore horizontal accuracy field bit#</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY_BIT" value="7">
+                  <description>ignore vertical accuracy field bit#</description>
+              </entry>
+          </enum>
           <enum name="GPS_INPUT_IGNORE_FLAGS">
               <entry name="GPS_INPUT_IGNORE_FLAG_ALT" value="1">
                   <description>ignore altitude field</description>


### PR DESCRIPTION
GPS_INPUT_IGNORE_FLAGS the location of each bit is a number.
Bit 7 = 128, bit 6 = 64, .. bit 0 = 1.
In this value, you can not get a bit of information to direct.
For example, to use the bitset function.
bit7 = 7, bit6 = 6, .. bit0 = 0
To define the bit number.