### PR TITLE
Adding PreArm status flag to HEARTBEAT message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2295,7 +2295,6 @@
                <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
                <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
                <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
-               <field type="uint8_t" name="prearm_status">PreArm status flag</field>
                <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
           </message>
           <message id="1" name="SYS_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3698,7 +3698,7 @@
                <field type="uint64_t" name="initial_timestamp">initial timestamp</field>
           </message>
 
-	  <message id="257" name="BUTTON_CHANGE">
+		<message id="257" name="BUTTON_CHANGE">
             <description>Report button state change</description>
             <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field name="last_change_ms" type="uint32_t">Time of last change of button state</field>
@@ -3710,6 +3710,12 @@
             <field name="target_system" type="uint8_t">System ID</field>
             <field name="target_component" type="uint8_t">Component ID</field>
             <field name="tune" type="char[30]">tune in board specific format</field>
+          </message>
+		  
+		  <message id="259" name="PREARM_STATUS">
+            <description>Report prearm check value</description>
+            <field type="uint8_t" name="prearm_status">PreArm status flag</field>
+            <field type="uint8_t" name="prearm_rc_status">PreArm RC status flag</field>
           </message>
           
         </messages>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -183,7 +183,6 @@
                <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAGS ENUM in mavlink/include/mavlink_types.h</field>
                <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
                <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
-               <field type="uint8_t" name="prearm_status">PreArm status flag</field>
                <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version</field>
           </message>
     </messages>


### PR DESCRIPTION
Adding this status flag will make external devices more consistent to real state of the FC (ex: led controllers)