### PR TITLE
ardupilot: add VISION_POSITION_DELTA message definition

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1374,5 +1374,14 @@
       <field name="f_dot" type="float">projection operator derivative</field>
       <field name="u" type="float">u adaptive controlled output command</field>
     </message>
+    <!-- camera vision based attitude and position delta message -->
+    <message id="11011" name="VISION_POSITION_DELTA">
+      <description>camera vision based attitude and position deltas</description>
+      <field name="time_usec" type="uint64_t">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field name="time_delta_usec" type="uint64_t">Time in microseconds since the last reported camera frame</field>
+      <field type="float[3]" name="angle_delta">Defines a rotation vector in body frame that rotates the vehicle from the previous to the current orientation</field>
+      <field type="float[3]" name="position_delta">Change in position in meters from previous to current frame rotated into body frame (0=forward, 1=right, 2=down)</field>
+      <field type="float" name="confidence">normalised confidence value from 0 to 100</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
This adds a new VISION_POSITION_DELTA mavlink message to the ArduPilot specific messages.

This message could probably be integrated into common.xml but there will be more developments related to adding SLAM support that might lead us to add more field to this message.  Because ArduPilot is the only user for the moment I think it's probably ok to leave it in the ardupilot specific set.

Here is a blog post explaining the setup including a video: http://discuss.ardupilot.org/t/ardupilot-openkai-zed-for-non-gps-navigation