### PR TITLE
ArduPilot: Deprecate BATTERY2 message

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1151,7 +1151,7 @@
       <!-- future proofing -->
     </message>
     <message id="181" name="BATTERY2">
-      <description>2nd Battery status</description>
+      <description>Deprecated. Use BATTERY_STATUS instead. 2nd Battery status</description>
       <field name="voltage" type="uint16_t">voltage in millivolts</field>
       <field name="current_battery" type="int16_t">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
     </message>


### PR DESCRIPTION
Deprecates BATTERY2 in favour of BATTERY_STATUS. We will need to keep sending the message for awhile, but it's worth pointing users at the new messages.