### PR TITLE
ArduPilot: Correct an off by 1 error on accel cal reporting

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -13,8 +13,8 @@
       <entry value="4" name="ACCELCAL_VEHICLE_POS_NOSEDOWN"/>
       <entry value="5" name="ACCELCAL_VEHICLE_POS_NOSEUP"/>
       <entry value="6" name="ACCELCAL_VEHICLE_POS_BACK"/>
-      <entry value="16777216" name="ACCELCAL_VEHICLE_POS_SUCCESS"/>
-      <entry value="16777217" name="ACCELCAL_VEHICLE_POS_FAILED"/>
+      <entry value="16777215" name="ACCELCAL_VEHICLE_POS_SUCCESS"/>
+      <entry value="16777216" name="ACCELCAL_VEHICLE_POS_FAILED"/>
     </enum>
     <!-- ardupilot specific MAV_CMD_* commands -->
     <enum name="MAV_CMD">


### PR DESCRIPTION
I'm not sure how but the indexs used before were off by one, which resulted in float round off errors. I had tested this so I'm not sure how I had stuffed up the submitted PR...