### PR TITLE
Add units to RTK accuracy information

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3495,7 +3495,7 @@
       <field type="int32_t" name="baseline_a_mm" units="mm">Current baseline in ECEF x or NED north component in mm.</field>
       <field type="int32_t" name="baseline_b_mm" units="mm">Current baseline in ECEF y or NED east component in mm.</field>
       <field type="int32_t" name="baseline_c_mm" units="mm">Current baseline in ECEF z or NED down component in mm.</field>
-      <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
+      <field type="uint32_t" name="accuracy" units="c%">Current estimate of baseline accuracy</field>
       <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
     </message>
     <message id="128" name="GPS2_RTK">
@@ -3511,7 +3511,7 @@
       <field type="int32_t" name="baseline_a_mm" units="mm">Current baseline in ECEF x or NED north component in mm.</field>
       <field type="int32_t" name="baseline_b_mm" units="mm">Current baseline in ECEF y or NED east component in mm.</field>
       <field type="int32_t" name="baseline_c_mm" units="mm">Current baseline in ECEF z or NED down component in mm.</field>
-      <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
+      <field type="uint32_t" name="accuracy" units="c%">Current estimate of baseline accuracy</field>
       <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
     </message>
     <message id="129" name="SCALED_IMU3">


### PR DESCRIPTION
The Emlid reach provides an "AR ratio" accuracy information that can be mapped to a centipercent (c%) unit.

I do not know about the other GPSs.