### PR TITLE
ArduPilot: Add airspeed variance to EKF_STATUS_REPORT

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1284,6 +1284,8 @@
       <field type="float" name="pos_vert_variance">Vertical Position variance</field>
       <field type="float" name="compass_variance">Compass variance</field>
       <field type="float" name="terrain_alt_variance">Terrain Altitude variance</field>
+      <extensions/>
+      <field type="float" name="airspeed_variance">Airspeed variance</field>
     </message>
     <!-- realtime PID tuning message -->
     <message id="194" name="PID_TUNING">


### PR DESCRIPTION
It would be highly valuable to expose this information to the GCS, as it's one of the better indicators of a failing airspeed system.