### PR TITLE
ardupilot: add DO_WINCH command

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -210,6 +210,16 @@
         <param index="6">Magic number</param>
         <param index="7">Magic number</param>
       </entry>
+      <entry value="42600" name="MAV_CMD_DO_WINCH">
+        <description>Command to operate winch</description>
+        <param index="1">winch number (0 for the default winch, otherwise a number from 1 to max number of winches on the vehicle)</param>
+        <param index="2">action (0=relax, 1=relative length control, 2=rate control.  See WINCH_ACTIONS enum)</param>
+        <param index="3">release length (cable distance to unwind in meters, negative numbers to wind in cable)</param>
+        <param index="4">release rate (meters/second)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
     </enum>
     <!-- AP_Limits Enums -->
     <enum name="LIMITS_STATE">
@@ -274,6 +284,19 @@
       </entry>
       <entry value="1" name="GRIPPER_ACTION_GRAB">
         <description>gripper grabs onto cargo</description>
+      </entry>
+    </enum>
+    <!-- winch action enum -->
+    <enum name="WINCH_ACTIONS">
+      <description>Winch actions</description>
+      <entry value="0" name="WINCH_RELAXED">
+        <description>relax winch</description>
+      </entry>
+      <entry value="1" name="WINCH_RELATIVE_LENGTH_CONTROL">
+        <description>winch unwinds or winds specified length of cable optionally using specified rate</description>
+      </entry>
+      <entry value="2" name="WINCH_RATE_CONTROL">
+        <description>winch unwinds or winds cable at specified rate in meters/seconds</description>
       </entry>
     </enum>
     <!-- Camera event types -->

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -160,9 +160,9 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="42501" name="MAV_CMD_GIMBAL_RESET">
-        <description>Causes the gimbal to reset and boot as if it was just powered on</description>
-        <param index="1">Empty</param>
+      <entry value="42427" name="MAV_CMD_SET_FACTORY_TEST_MODE">
+        <description>Command autopilot to get into factory test/diagnostic mode</description>
+        <param index="1">0 means get out of test mode, 1 means get into test mode</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -170,9 +170,9 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="42427" name="MAV_CMD_SET_FACTORY_TEST_MODE">
-        <description>Command autopilot to get into factory test/diagnostic mode</description>
-        <param index="1">0 means get out of test mode, 1 means get into test mode</param>
+      <entry value="42501" name="MAV_CMD_GIMBAL_RESET">
+        <description>Causes the gimbal to reset and boot as if it was just powered on</description>
+        <param index="1">Empty</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>


### PR DESCRIPTION
This PR does the following:

- adds a new DO_WINCH command for use within a mission-item, command-long or command-int message to support controlling a winch for lowering packages from a vehicle
- changes the order in which the MAV_CMD_GIMBAL_RESET and MAV_CMD_SET_FACTORY_TEST_MODE commands appear in ardupilotmega.xml so that the order is consistent with the command-id value.  This is a non-functional change.