### PR TITLE
Ardupilot: Message with wheels' cumulative distances added.

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1606,7 +1606,7 @@
       <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
       <field name="time_usec" type="uint64_t">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
       <field type="uint8_t" name="count">Number of wheels reported</field>
-      <field type="float[4]" name="distance" units="m">Distance traveled by each wheel (m)</field>
+      <field type="float[16]" name="distance" units="m">Distance traveled by each wheel (m)</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1605,7 +1605,7 @@
     <message id="11040" name="WHEEL_DISTANCE">
       <description>Cumulative distances traveled by each wheel (forward rotations increase these values, backward - decrease).</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (synced to UNIX time or since system boot)</field>
-      <field type="uint8_t" name="count">Number of wheels reported</field>
+      <field type="uint8_t" name="count">Number of wheels reported in the array field (distance)</field>
       <field type="float[16]" name="distance" units="m">Distance traveled by each wheel</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1604,7 +1604,7 @@
     <!-- wheel traveled distance message -->
     <message id="11030" name="WHEEL_DISTANCE">
       <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
-      <field name="time_usec" type="uint64_t">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
       <field type="uint8_t" name="count">Number of wheels reported</field>
       <field type="float[16]" name="distance" units="m">Distance traveled by each wheel (m)</field>
     </message>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1602,11 +1602,11 @@
       <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
     </message>
     <!-- wheel traveled distance message -->
-    <message id="11030" name="WHEEL_DISTANCE">
-      <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+    <message id="11040" name="WHEEL_DISTANCE">
+      <description>Cumulative distances traveled by each wheel (forward rotations increase these values, backward - decrease).</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (synced to UNIX time or since system boot)</field>
       <field type="uint8_t" name="count">Number of wheels reported</field>
-      <field type="float[16]" name="distance" units="m">Distance traveled by each wheel (m)</field>
+      <field type="float[16]" name="distance" units="m">Distance traveled by each wheel</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1601,5 +1601,12 @@
       <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
       <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
     </message>
+    <!-- wheel traveled distance message -->
+    <message id="11030" name="WHEEL_DISTANCE">
+      <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
+      <field name="time_usec" type="uint64_t">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="uint8_t" name="count">Number of wheels reported</field>
+      <field type="float[4]" name="distance" units="m">Distance traveled by each wheel (m)</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
This PR is aimed to make possible computing of wheel odometry on a companion computer with encoders connected to autopilot. Instead of using existing RPM message, this message allows more accurate odometry calculations.
Corresponding topic is discussed in [mavlink/mavlink #799](https://github.com/mavlink/mavlink/pull/799).