### PR TITLE
Add FUEL_STATUS to ardupilotmega.xml

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1473,5 +1473,13 @@
       <field name="AOA" type="float">Angle of Attack (degrees)</field>
       <field name="SSA" type="float">Side Slip Angle (degrees)</field>
     </message>
+    <!-- Fuel Status message -->
+    <message id="11030" name="FUEL_STATUS">
+      <description>Fuel Tank Information</description>
+      <field type="float" name="vol_remaining">Volume of fuel remaining (cm^3) </field>
+      <field type="float" name="percent_remaining">Percent of total fuel remaining</field>
+      <field type="float" name="consumption_rate">Fuel consumption rate (cm^3/min)</field>
+      <field type="float" name="temperature">Fuel Temperature (celsius)</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
I am proposing a FUEL_STATUS message to enable support for fuel tank monitoring. I have created an [AP_FuelMonitor](https://github.com/DavidIngraham/ardupilot/tree/AP_FuelMonitor) library that supports analog fuel level sensors and a basic burn rate estimate (other sensors coming soon).

I am open to comment on the exact fields in this message. I currently have defined the following four fields:

VOL_REMAINING (float, cm^3)
PERCENT_REMAINING (float, %)
CONSUMPTION_RATE (float, cm^3/min)
TEMPERATURE (float, celsius)

These fields are consistent with UAVCAN (other than the temeprature units).

A few points for discussion:

- @tridge noted that we may wish to have the measurements present the fuel used, rather then the fuel remaining. This would be beneficial in the case that a user is using a flow sensor and realizes that they forgot to set the proper volume in the tank before takeoff. However, it would be a bit more confusing in situations where a level sensor is used. It would also not be compatible with UAVCAN

- We may wish to add an additional field for tank instance like we have with BATTERY_STATUS. However, it is probably very unlikely that we will see a UAV with two completely independent fuel systems.