### PR TITLE
Add a mapping of ArduPilot custom flight modes

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -918,6 +918,84 @@
         <description>Stalling and steering towards the land point</description>
       </entry>
     </enum>
+    <enum name="PLANE_MODE">
+      <description>A mapping of plane flight modes for custom_mode field of heartbeat</description>
+      <entry value="0"  name="PLANE_MODE_MANUAL"/>
+      <entry value="1"  name="PLANE_MODE_CIRCLE"/>
+      <entry value="2"  name="PLANE_MODE_STABILIZE"/>
+      <entry value="3"  name="PLANE_MODE_TRAINING"/>
+      <entry value="4"  name="PLANE_MODE_ACRO"/>
+      <entry value="5"  name="PLANE_MODE_FLY_BY_WIRE_A"/>
+      <entry value="6"  name="PLANE_MODE_FLY_BY_WIRE_B"/>
+      <entry value="7"  name="PLANE_MODE_CRUISE"/>
+      <entry value="8"  name="PLANE_MODE_AUTOTUNE"/>
+      <entry value="10" name="PLANE_MODE_AUTO"/>
+      <entry value="11" name="PLANE_MODE_RTL"/>
+      <entry value="12" name="PLANE_MODE_LOITER"/>
+      <entry value="14" name="PLANE_MODE_AVOID_ADSB"/>
+      <entry value="15" name="PLANE_MODE_GUIDED"/>
+      <entry value="16" name="PLANE_MODE_INITIALIZING"/>
+      <entry value="17" name="PLANE_MODE_QSTABILIZE"/>
+      <entry value="18" name="PLANE_MODE_QHOVER"/>
+      <entry value="19" name="PLANE_MODE_QLOITER"/>
+      <entry value="20" name="PLANE_MODE_QLAND"/>
+      <entry value="21" name="PLANE_MODE_QRTL"/>
+    </enum>
+    <enum name="COPTER_MODE">
+      <description>A mapping of copter flight modes for custom_mode field of heartbeat</description>
+      <entry value="0"  name="COPTER_MODE_STABILIZE"/>
+      <entry value="1"  name="COPTER_MODE_ACRO"/>
+      <entry value="2"  name="COPTER_MODE_ALT_HOLD"/>
+      <entry value="3"  name="COPTER_MODE_AUTO"/>
+      <entry value="4"  name="COPTER_MODE_GUIDED"/>
+      <entry value="5"  name="COPTER_MODE_LOITER"/>
+      <entry value="6"  name="COPTER_MODE_RTL"/>
+      <entry value="7"  name="COPTER_MODE_CIRCLE"/>
+      <entry value="9"  name="COPTER_MODE_LAND"/>
+      <entry value="11" name="COPTER_MODE_DRIFT"/>
+      <entry value="13" name="COPTER_MODE_SPORT"/>
+      <entry value="14" name="COPTER_MODE_FLIP"/>
+      <entry value="15" name="COPTER_MODE_AUTOTUNE"/>
+      <entry value="16" name="COPTER_MODE_POSHOLD"/>
+      <entry value="17" name="COPTER_MODE_BRAKE"/>
+      <entry value="18" name="COPTER_MODE_THROW"/>
+      <entry value="19" name="COPTER_MODE_AVOID_ADSB"/>
+      <entry value="20" name="COPTER_MODE_GUIDED_NOGPS"/>
+      <entry value="21" name="COPTER_MODE_SMART_RTL"/>
+    </enum>
+    <enum name="SUB_MODE">
+      <description>A mapping of sub flight modes for custom_mode field of heartbeat</description>
+      <entry value="0"  name="SUB_MODE_STABILIZE"/>
+      <entry value="1"  name="SUB_MODE_ACRO"/>
+      <entry value="2"  name="SUB_MODE_ALT_HOLD"/>
+      <entry value="3"  name="SUB_MODE_AUTO"/>
+      <entry value="4"  name="SUB_MODE_GUIDED"/>
+      <entry value="7"  name="SUB_MODE_CIRCLE"/>
+      <entry value="9"  name="SUB_MODE_SURFACE"/>
+      <entry value="16" name="SUB_MODE_POSHOLD"/>
+      <entry value="19" name="SUB_MODE_MANUAL"/>
+    </enum>
+    <enum name="ROVER_MODE">
+      <description>A mapping of rover flight modes for custom_mode field of heartbeat</description>
+      <entry value="0"  name="ROVER_MODE_MANUAL"/>
+      <entry value="1"  name="ROVER_MODE_ACRO"/>
+      <entry value="3"  name="ROVER_MODE_STEERING"/>
+      <entry value="4"  name="ROVER_MODE_HOLD"/>
+      <entry value="10" name="ROVER_MODE_AUTO"/>
+      <entry value="11" name="ROVER_MODE_RTL"/>
+      <entry value="12" name="ROVER_MODE_SMART_RTL"/>
+      <entry value="15" name="ROVER_MODE_GUIDED"/>
+      <entry value="16" name="ROVER_MODE_INITIALIZING"/>
+    </enum>
+    <enum name="TRACKER_MODE">
+      <description>A mapping of antenna tracker flight modes for custom_mode field of heartbeat</description>
+      <entry value="0"  name="TRACKER_MODE_MANUAL"/>
+      <entry value="1"  name="TRACKER_MODE_STOP"/>
+      <entry value="2"  name="TRACKER_MODE_SCAN"/>
+      <entry value="3"  name="TRACKER_MODE_SERVO_TEST"/>
+      <entry value="10" name="TRACKER_MODE_AUTO"/>
+      <entry value="16" name="TRACKER_MODE_INITIALIZING"/>
+    </enum>
   </enums>
   <messages>
     <message id="150" name="SENSOR_OFFSETS">


### PR DESCRIPTION
This maps out all currently supported flight modes that are reported via the `custom_mode` field of heartbeat.