### PR TITLE
ardupilot: added ESC_TELEMETRY_* messages

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1556,5 +1556,33 @@
       <field name="AOA" type="float" units="deg">Angle of Attack (degrees)</field>
       <field name="SSA" type="float" units="deg">Side Slip Angle (degrees)</field>
     </message>
+    <message id="11030" name="ESC_TELEMETRY_1_TO_4">
+      <description>ESC Telemetry Data for ESCs 1 to 4, matching data sent by BLHeli ESCs</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM)</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535)</field>
+    </message>
+    <message id="11031" name="ESC_TELEMETRY_5_TO_8">
+      <description>ESC Telemetry Data for ESCs 5 to 8, matching data sent by BLHeli ESCs</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM)</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535)</field>
+    </message>
+    <message id="11032" name="ESC_TELEMETRY_9_TO_12">
+      <description>ESC Telemetry Data for ESCs 9 to 12, matching data sent by BLHeli ESCs</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM)</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535)</field>
+    </message>
+    
   </messages>
 </mavlink>


### PR DESCRIPTION
these are for feedback from BLHeli and KISS ESCs. It uses three separate messages to minimise bandwith costs for smaller vehicles.
