### PR TITLE
ardupilotmega: add rover loiter mode

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -982,6 +982,7 @@
       <entry value="1"  name="ROVER_MODE_ACRO"/>
       <entry value="3"  name="ROVER_MODE_STEERING"/>
       <entry value="4"  name="ROVER_MODE_HOLD"/>
+      <entry value="5"  name="ROVER_MODE_LOITER"/>
       <entry value="10" name="ROVER_MODE_AUTO"/>
       <entry value="11" name="ROVER_MODE_RTL"/>
       <entry value="12" name="ROVER_MODE_SMART_RTL"/>


### PR DESCRIPTION
This adds the enum value for the new Rover loiter mode.  Main ardupilot PR is here: https://github.com/ArduPilot/ardupilot/pull/8286

thanks to @peterbarker for reminding me I need to do this as part of adding a new flight mode.  I'll add this to our developer wiki pages on the subject.