### PR TITLE
dpix instead of dpixels to be consistent with the existing "pix" unit abreviation

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3518,15 +3518,15 @@
       <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX)</field>
       <field type="uint8_t" name="sensor_id">Sensor ID</field>
-      <field type="int16_t" name="flow_x" units="dpixels">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
-      <field type="int16_t" name="flow_y" units="dpixels">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
-      <field type="float" name="flow_comp_m_x" units="m">Flow in meters in x-sensor direction, angular-speed compensated</field>
-      <field type="float" name="flow_comp_m_y" units="m">Flow in meters in y-sensor direction, angular-speed compensated</field>
+      <field type="int16_t" name="flow_x" units="dpix">Flow in x-sensor direction</field>
+      <field type="int16_t" name="flow_y" units="dpix">Flow in y-sensor direction</field>
+      <field type="float" name="flow_comp_m_x" units="m">Flow in x-sensor direction, angular-speed compensated</field>
+      <field type="float" name="flow_comp_m_y" units="m">Flow in y-sensor direction, angular-speed compensated</field>
       <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
-      <field type="float" name="ground_distance" units="m">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
+      <field type="float" name="ground_distance" units="m">Ground distance. Positive value: distance known. Negative value: Unknown distance</field>
       <extensions/>
-      <field type="float" name="flow_rate_x" units="rad/s">Flow rate in radians/second about X axis</field>
-      <field type="float" name="flow_rate_y" units="rad/s">Flow rate in radians/second about Y axis</field>
+      <field type="float" name="flow_rate_x" units="rad/s">Flow rate about X axis</field>
+      <field type="float" name="flow_rate_y" units="rad/s">Flow rate about Y axis</field>
     </message>
     <message id="101" name="GLOBAL_VISION_POSITION_ESTIMATE">
       <field type="uint64_t" name="usec" units="us">Timestamp (microseconds, synced to UNIX time or since system boot)</field>


### PR DESCRIPTION
requires ardupilot/pymavlink#193