### PR TITLE
Tag MAG_CAL_REPORT orientation values

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1390,8 +1390,8 @@
       <field type="float" name="offdiag_z">Z off-diagonal (matrix 32 and 23)</field>
       <extensions/>
       <field type="float" name="orientation_confidence">Confidence in orientation (higher is better)</field>      
-      <field type="uint8_t" name="old_orientation">orientation before calibration </field>
-      <field type="uint8_t" name="new_orientation">orientation before calibration</field>
+      <field type="uint8_t" name="old_orientation" enum="MAV_SENSOR_ORIENTATION">orientation before calibration </field>
+      <field type="uint8_t" name="new_orientation" enum="MAV_SENSOR_ORIENTATION">orientation after calibration</field>
     </message>
     <!-- EKF status message from autopilot to GCS. -->
     <message id="193" name="EKF_STATUS_REPORT">


### PR DESCRIPTION
mavlink/mavlink updated to our orientation values, so we can tag this with the correct enum now (we still need to pull the change into our repo as well), which should help GCS's create reasonable UI's. This also fixes a copy paste error in the description of `new_orientation`