### PR TITLE
OBSTACLE_DISTANCE: add higher angle resolution and angle offset

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4548,10 +4548,13 @@
       <description>Obstacle distances in front of the sensor, starting from the left in increment degrees to the right</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="uint8_t" name="sensor_type" enum="MAV_DISTANCE_SENSOR">Class id of the distance sensor type.</field>
-      <field type="uint16_t[72]" name="distances" units="cm">Distance of obstacles around the UAV with index 0 corresponding to local North. A value of 0 means that the obstacle is right in front of the sensor. A value of max_distance +1 means no obstacle is present. A value of UINT16_MAX for unknown/not used. In a array element, one unit corresponds to 1cm.</field>
-      <field type="uint8_t" name="increment" units="deg">Angular width in degrees of each array element.</field>
+      <field type="uint16_t[72]" name="distances" units="cm">Distance of obstacles around the UAV with index 0 corresponding to local forward + angle_offset. A value of 0 means that the obstacle is right in front of the sensor. A value of max_distance +1 means no obstacle is present. A value of UINT16_MAX for unknown/not used. In a array element, one unit corresponds to 1cm.</field>
+      <field type="uint8_t" name="increment" units="deg">Angular width in degrees of each array element. (Ignored if increment_f greater than 0).</field>
       <field type="uint16_t" name="min_distance" units="cm">Minimum distance the sensor can measure.</field>
       <field type="uint16_t" name="max_distance" units="cm">Maximum distance the sensor can measure.</field>
+      <extensions/>
+      <field type="float" name="increment_f" units="deg">Angular width in degrees of each array element as a float. If greater than 0 then this value is used instead of the uint8_t increment field.</field>
+      <field type="float" name="angle_offset" units="deg">Relative angle offset of the 0-index element in the distances array. Value of 0 corresponds to forward. Positive values are offsets to the right.</field>
     </message>
     <message id="331" name="ODOMETRY">
       <description>Odometry message to communicate odometry information with an external interface. Fits ROS REP 147 standard for aerial vehicles (http://www.ros.org/reps/rep-0147.html).</description>


### PR DESCRIPTION
This MAVLink v2 packet allows for flexible obstacle detection from multiple sensors of varying resolution while still being backwards compatible.

increment_f (to override increment):
When forced to send exactly 72 samples, having an integer spacing just didn't make sense. Needed to be float so that the correct angular range was understood

angle_offset:
Same as, and adds to, param "[PRX_YAW_CORR](http://ardupilot.org/rover/docs/parameters.html#prx-yaw-corr-proximity-sensor-yaw-correction)". However, if you have two sensors you can send multiple messages covering different areas (at varying resolutions). For example, a 360 degree spinning lidar + long-range forward radar/lidar + wide angle sonar(s). With multiple messages, we can aggregate a better picture and down-scale the resolution to whatever the flight controller can handle in that version. And that will improve as we get fancier flight controllers with more memory Meanwhile, the data is no longer limited by the comms link, just on how to store it once received.

count:
Allow the option to send less than 72 distance values.