### PR TITLE
ardupilot: add sailboat throttle state waypoint type

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -241,6 +241,16 @@
         <param index="6">Reserved, send 0</param>
         <param index="7">Reserved, send 0</param>
       </entry>
+      <entry value="2900" name="MAV_CMD_DO_SET_SAILBOAT_THROTTLE_STATE" hasLocation="false" isDestination="false">
+        <description>Request change of sailboat throttle state</description>
+        <param index="1" label="State" enum="SAILBOAT_THROTTLE_STATE">The target sailboat throttle state</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
     </enum>
     <!-- AP_Limits Enums -->
     <enum name="LIMITS_STATE">
@@ -927,6 +937,12 @@
       <entry value="6" name="DEEPSTALL_STAGE_LAND">
         <description>Stalling and steering towards the land point.</description>
       </entry>
+    </enum>
+      <enum name="SAILBOAT_THROTTLE_STATE">
+      <description >Sailboat throttle state</description>
+      <entry value="0" name="NEVER"/>
+      <entry value="1" name="ASSIST"/>
+      <entry value="2" name="FORCE_MOTOR "/>
     </enum>
     <enum name="PLANE_MODE">
       <description>A mapping of plane flight modes for custom_mode field of heartbeat.</description>


### PR DESCRIPTION
this is my first go at a mavlink PR

This adds MAV_CMD_DO_SET_SAILBOAT_THROTTLE_STATE waypoint type required for https://github.com/ArduPilot/ardupilot/pull/11423 

no idea if a value of 2900 is a good idea?