### PR TITLE
common: Change mbar to hPa.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3752,8 +3752,8 @@
       <field type="float" name="xmag" units="gauss">X Magnetic field</field>
       <field type="float" name="ymag" units="gauss">Y Magnetic field</field>
       <field type="float" name="zmag" units="gauss">Z Magnetic field</field>
-      <field type="float" name="abs_pressure" units="mbar">Absolute pressure</field>
-      <field type="float" name="diff_pressure" units="mbar">Differential pressure</field>
+      <field type="float" name="abs_pressure" units="hPa">Absolute pressure</field>
+      <field type="float" name="diff_pressure" units="hPa">Differential pressure</field>
       <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
       <field type="float" name="temperature" units="degC">Temperature</field>
       <field type="uint16_t" name="fields_updated" display="bitmask">Bitmap for fields that have updated since last message, bit 0 = xacc, bit 12: temperature</field>
@@ -3785,8 +3785,8 @@
       <field type="float" name="xmag" units="gauss">X Magnetic field</field>
       <field type="float" name="ymag" units="gauss">Y Magnetic field</field>
       <field type="float" name="zmag" units="gauss">Z Magnetic field</field>
-      <field type="float" name="abs_pressure" units="mbar">Absolute pressure</field>
-      <field type="float" name="diff_pressure" units="mbar">Differential pressure (airspeed)</field>
+      <field type="float" name="abs_pressure" units="hPa">Absolute pressure</field>
+      <field type="float" name="diff_pressure" units="hPa">Differential pressure (airspeed)</field>
       <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
       <field type="float" name="temperature" units="degC">Temperature</field>
       <field type="uint32_t" name="fields_updated" display="bitmask">Bitmap for fields that have updated since last message, bit 0 = xacc, bit 12: temperature, bit 31: full reset of attitude/position/velocities/etc was performed in sim.</field>


### PR DESCRIPTION
I feel pressure and mbar is a unit of the past, and now hPa is a major measure.
hPa is also used for the design data of the pressure sensor adopted by ZERO.
I think it's better to match the unit to the present.

ZERO:
https://mrobotics.io/introducing-the-new-mro-control-zero-autopilot/

DPS310:
https://www.infineon.com/dgdl/Infineon-DPS310-DS-v01_00-EN.pdf?fileId=5546d462576f34750157750826c42242