### PR TITLE
ardupilot: added SERIAL_CONTROL_SERIALn enums

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2438,6 +2438,36 @@
       <entry value="10" name="SERIAL_CONTROL_DEV_SHELL">
         <description>system shell</description>
       </entry>
+      <entry value="100" name="SERIAL_CONTROL_SERIAL0">
+        <description>SERIAL0</description>
+      </entry>
+      <entry value="101" name="SERIAL_CONTROL_SERIAL1">
+        <description>SERIAL1</description>
+      </entry>
+      <entry value="102" name="SERIAL_CONTROL_SERIAL2">
+        <description>SERIAL2</description>
+      </entry>
+      <entry value="103" name="SERIAL_CONTROL_SERIAL3">
+        <description>SERIAL3</description>
+      </entry>
+      <entry value="104" name="SERIAL_CONTROL_SERIAL4">
+        <description>SERIAL4</description>
+      </entry>
+      <entry value="105" name="SERIAL_CONTROL_SERIAL5">
+        <description>SERIAL5</description>
+      </entry>
+      <entry value="106" name="SERIAL_CONTROL_SERIAL6">
+        <description>SERIAL6</description>
+      </entry>
+      <entry value="107" name="SERIAL_CONTROL_SERIAL7">
+        <description>SERIAL7</description>
+      </entry>
+      <entry value="108" name="SERIAL_CONTROL_SERIAL8">
+        <description>SERIAL8</description>
+      </entry>
+      <entry value="109" name="SERIAL_CONTROL_SERIAL9">
+        <description>SERIAL9</description>
+      </entry>
     </enum>
     <enum name="SERIAL_CONTROL_FLAG">
       <description>SERIAL_CONTROL flags (bitmask)</description>


### PR DESCRIPTION
to allow for SERIAL_CONTROL of any port