### PR TITLE
common: added extension for GPS_RAW_INT and GPS2_RAW for yaw

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3352,6 +3352,7 @@
       <field type="uint32_t" name="v_acc" units="mm">Altitude uncertainty. Positive for up.</field>
       <field type="uint32_t" name="vel_acc" units="mm">Speed uncertainty. Positive for up.</field>
       <field type="uint32_t" name="hdg_acc" units="degE5">Heading / track uncertainty</field>
+      <field type="uint16_t" name="yaw" units="cdeg">Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use 65535 if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.</field>
     </message>
     <message id="25" name="GPS_STATUS">
       <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION for the global position estimate. This message can contain information for up to 20 satellites.</description>
@@ -4301,6 +4302,8 @@
       <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
       <field type="uint8_t" name="dgps_numch">Number of DGPS satellites</field>
       <field type="uint32_t" name="dgps_age" units="ms">Age of DGPS info</field>
+      <extensions/>
+      <field type="uint16_t" name="yaw" units="cdeg">Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use 65535 if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.</field>
     </message>
     <message id="125" name="POWER_STATUS">
       <description>Power supply status</description>


### PR DESCRIPTION
this allows moving baseline GPS configurations to show their yaw
solution to the GCS. It also allows a GCS to display a warning if the
GPS is configured to provide yaw (eg. configured as a moving baseline
rover) and currently cannot provide yaw