### PR TITLE
Common: SYS_STATUS sensor initialized extension

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3266,6 +3266,8 @@
       <field type="uint16_t" name="errors_count2">Autopilot-specific errors</field>
       <field type="uint16_t" name="errors_count3">Autopilot-specific errors</field>
       <field type="uint16_t" name="errors_count4">Autopilot-specific errors</field>
+      <extensions/>
+      <field type="uint32_t" name="onboard_control_sensors_initialised" enum="MAV_SYS_STATUS_SENSOR" display="bitmask" print_format="0x%04x">Bitmap showing which onboard controllers and sensors are initialised. Value of 0: not initialised. Value of 1: initialised.</field>
     </message>
     <message id="2" name="SYSTEM_TIME">
       <description>The system time is the time of the master clock, typically the computer clock of the main onboard computer.</description>


### PR DESCRIPTION
This add a initialized extension to the SYS_STATUS message, this allows the GCS to tell if sensors are not healthy or just not ready.

 https://github.com/ArduPilot/ardupilot/issues/12456?fbclid=IwAR0ZUy8i7SZuYEQ6VALjxvKHorK6YdFhNZ0FHkq5Ijgg_DR5FMlIt4kQWdU

Our sensors do not, for the most part, know if they are initialized or not, I am planning that once they become healthy the first time they are then initialized for the purposes of this extension.