### PR TITLE
ardupilotmega: add initialized bit to EKF_STATUS_FLAGS

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -870,6 +870,9 @@
       <entry value="512" name="EKF_PRED_POS_HORIZ_ABS">
         <description>Set if EKF's predicted horizontal position (absolute) estimate is good.</description>
       </entry>
+      <entry value="1024" name="EKF_UNINITIALIZED">
+        <description>Set if EKF has never been healthy.</description>
+      </entry>
     </enum>
     <enum name="PID_TUNING_AXIS">
       <entry value="1" name="PID_TUNING_ROLL"/>


### PR DESCRIPTION
alternative for  https://github.com/ArduPilot/mavlink/pull/124
https://github.com/ArduPilot/ardupilot/pull/13457

For the purpose of reporting initializing AHRS rather than bad on boot.