### PR TITLE
Add scripting MAVLink commands

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -256,6 +256,18 @@
         <param index="6">Empty.</param>
         <param index="7">Empty.</param>
       </entry>
+      <entry value="42701" name="MAV_CMD_SCRIPTING">
+        <description>Control onboard scripting.</description>
+        <param index="1" enum="SCRIPTING_CMD">Scripting command to execute</param>
+      </entry>
+    </enum>
+    <enum name="SCRIPTING_CMD">
+      <entry value="0" name="SCRIPTING_CMD_REPL_START">
+        <description>Start a REPL session.</description>
+      </entry>
+      <entry value="1" name="SCRIPTING_CMD_REPL_STOP">
+        <description>End a REPL session.</description>
+      </entry>
     </enum>
     <!-- AP_Limits Enums -->
     <enum name="LIMITS_STATE">


### PR DESCRIPTION
Extending the `SCRIPTING_CMD` enum would give us an easy way to restart scripts for example. This is also needed for https://github.com/ArduPilot/ardupilot/pull/13547