### PR TITLE
ardupilotmega: remove PID_TUNING units

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1485,8 +1485,8 @@
     <message id="194" name="PID_TUNING">
       <description>PID tuning information.</description>
       <field type="uint8_t" name="axis" enum="PID_TUNING_AXIS">Axis.</field>
-      <field type="float" name="desired" units="deg/s">Desired rate.</field>
-      <field type="float" name="achieved" units="deg/s">Achieved rate.</field>
+      <field type="float" name="desired">Desired rate.</field>
+      <field type="float" name="achieved">Achieved rate.</field>
       <field type="float" name="FF">FF component.</field>
       <field type="float" name="P">P component.</field>
       <field type="float" name="I">I component.</field>


### PR DESCRIPTION
This removes the units from the PID tuning message as we never abide by them anyway

https://github.com/ArduPilot/ardupilot/pull/14382