### PR TITLE
Ardupilotmega: add OBSTACLE_DISTANCE_3D message

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1763,5 +1763,19 @@
       <field type="float" name="max_value">OSD parameter maximum value.</field>
       <field type="float" name="increment">OSD parameter increment.</field>
     </message>
+    <message id="11037" name="OBSTACLE_DISTANCE_3D">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>Obstacle located as a 3D vector.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="sensor_type" enum="MAV_DISTANCE_SENSOR">Class id of the distance sensor type.</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame of reference.</field>
+      <field type="uint16_t" name="obstacle_id"> Unique ID given to each obstacle so that its movement can be tracked. Use UINT16_MAX if object ID is unknown or cannot be determined.</field>
+      <field type="float" name="x" units="m"> X position of the obstacle.</field>
+      <field type="float" name="y" units="m"> Y position of the obstacle.</field>
+      <field type="float" name="z" units="m"> Z position of the obstacle.</field>
+      <field type="float" name="min_distance" units="m">Minimum distance the sensor can measure.</field>
+      <field type="float" name="max_distance" units="m">Maximum distance the sensor can measure.</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
This is a WIP.
This PR adds the ability to send obstacle distance message, in body frame from a 3-D depth camera. 
We assume the field of view is divided in a 3x3 grid like such:

![vlcsnap-2020-08-20-11h18m09s677](https://user-images.githubusercontent.com/36970042/90723602-b2478180-e2da-11ea-8249-db44b939802a.jpg)


We take the closest distance in each individual box, pack it into a NEU frame distance vector in meters and send it.
Furthermore, this message also includes an "ID" field for future implementation of detecting obstacles and tagging them with a  unique ID.