### PR TITLE
Sync to upstream 2020-12-07 - controversial patches

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3591,7 +3591,7 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the mission item.</field>
-      <field type="uint8_t" name="current">false:0, true:1</field>
+      <field type="uint8_t" name="current">Not used.</field>
       <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>


### PR DESCRIPTION
> Mark COMMAND_INT.current as not used. (mavlink#1514)

@hamishwillee and @peterbarker seam to disagree on this one
