### PR TITLE
Sync to upstream 2020-12-09

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRARY_SOVERSION "0.0.0")
 # none required
 
 # options
+option(USE_SYSTEM_PYMAVLINK "Generate mavlink files with system-wide installed mavgen" OFF)
 option(WITH_TESTS "Build test programs." OFF)
 option(WITH_BUILD_DEPS "Build dependencies." OFF) # no deps currently to build
 option(WITH_BUILD_STATIC "Build preferring static linking." ON)
@@ -133,7 +134,23 @@ endif()
 configure_file(config.h.in config.h)
 install(FILES ${CMAKE_BINARY_DIR}/config.h DESTINATION include/${PROJECT_NAME} COMPONENT Dev)
 
-# mavlink generation
+# mavgen location for mavlink generation
+set(mavgen_EXECUTABLE_WITH_PYTHON_INVOCATION ${CMAKE_COMMAND} -E env "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_CURRENT_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pymavlink.tools.mavgen)
+if(USE_SYSTEM_PYMAVLINK)
+    find_program (
+        mavgen_EXECUTABLE
+        NAMES mavgen mavgen.py
+    )
+
+    # Fallback to Python invocation, if not found.
+    if (mavgen_EXECUTABLE-NOTFOUND)
+        set(mavgen_EXECUTABLE ${mavgen_EXECUTABLE_WITH_PYTHON_INVOCATION})
+    endif()
+else()
+    set(mavgen_EXECUTABLE ${mavgen_EXECUTABLE_WITH_PYTHON_INVOCATION})
+endif()
+message(STATUS "mavgen_EXECUTABLE: ${mavgen_EXECUTABLE}")
+
 macro(generateMavlink version definitions)
     foreach(definition ${definitions})
         set(targetName ${definition}-v${version})
@@ -141,16 +158,17 @@ macro(generateMavlink version definitions)
         message(STATUS "processing: ${definitionAbsPath}")
         add_custom_command( 
             OUTPUT ${targetName}-stamp
-            COMMAND PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_CURRENT_SOURCE_DIR} ${PYTHON_EXECUTABLE} -m pymavlink.tools.mavgen --lang=C --wire-protocol=${version}
-                --output=include/v${version} ${definitionAbsPath}
+            COMMAND ${mavgen_EXECUTABLE} --lang=C
+                                         --wire-protocol=${version}
+                                         --output=include/v${version}
+                                         ${definitionAbsPath}
             COMMAND touch ${targetName}-stamp
-            )
+        )
         add_custom_target(${targetName} ALL DEPENDS ${targetName}-stamp)
     endforeach()
 endmacro()
 
 # build
-set(mavgen -m pymavlink.tools.mavgen)
 set(v1.0Definitions
     ASLUAV.xml
     ardupilotmega.xml

--- a/component_information/parameter.schema.json
+++ b/component_information/parameter.schema.json
@@ -3,16 +3,12 @@
     "$schema":      "http://json-schema.org/draft-07/schema",
     "description":  "Schema for COMP_METADATA_TYPE_PARAMETER",
     "type":         "object",
-    
+
     "properties": {
         "version": {
             "description":  "Version number for the format of this file.",
             "type":         "integer",
             "minimum":      1
-        },
-        "uid": {
-            "description":  "Unique id for this metadata. Same as ```COMPONENT_INFORMATION. comp_metadata_uid```.",
-            "type":         "integer"
         },
         "scope": {
             "description":  "Scope to which this metadata applies. Firmware: Any vehicle running this same vehicles firmware type. VehicleGroup: Any vehicle running this same firmware and this vehicles group type (Fixed Wing, Multi-Rotor, VTOL, Rover). VehicleType: Any vehicle match this vehicles firmware type and specific vehicle type. Vehicle: Only applies to this specific vehicle.",
@@ -20,100 +16,120 @@
             "enum":         [ "Firmware", "VehicleGroup", "VehicleType", "Vehicle" ]
         },
         "parameters": {
-           "type": "array",
-                       
-            "properties": {
-                "name": {
-                    "description":  "Parameter Name.",
-                    "type":         "string",
-                    "pattern":      "^[a-zA-Z0-9_\\{\\}]{1,16}$",
-                    "comment":      "FOO{n}_BAR for name will match actual name of FOO1_BAR, FOO3_BAR and so forth." 
-                },
-                "type": {
-                    "description":  "Parameter type.",
-                    "type":         "string",
-                    "enum":         [ "Uint8", "Int8", "Uint16", "Int16", "Uint32", "Int32", "Float" ]
-                },
-                "shortDesc": {
-                    "description":  "Short user facing description/name for parameter. Used in UI intead of internal parameter name.",
-                    "type":         "string",
-                    "default":      "",
-                    "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'." 
-                },
-                "longDesc": {
-                    "description":  "Long user facing documentation of how the parameters works.",
-                    "type":         "string",
-                    "default":      "",
-                    "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'." 
-                },
-                "units": {
-                    "description":  "Units for parameter value.",
-                    "type":         "string",
-                    "default":      "",
-                    "comment":      "A 'Known Unit' allows a GCS to convert between units like meters to feet as needed. Known Units are: 'm/meter/meter', 'vertical m' - vertical distance, 'cm/px', 'm/s', 'C' - celcius, 'm^2', 'g' - grams, 'centi-degrees', 'radians', 'norm'."
-                },
-                "default": {
-                    "description":  "Default value for parameter.",
-                    "type":         "number",
-                    "comment":      "If a defaultValue is not specified, there is no default for the parameter available at all. A GCS should not provide an option to reset this parameter to default."
-                },
-                "decimalPlaces": {
-                    "description":  "Number of decimal places to show for user facing display.",
-                    "type":         "integer",
-                    "minimum":      0,
-                    "default":      7
-                },
-                "min": {
-                    "description":  "Minimum valid value",
-                    "type":         "number",
-                    "comment":      "If 'min' is not specified the minimum value is the minimum numeric value which can be represented by the type."
-                },
-                "max": {
-                    "description":  "Maximum valid value",
-                    "type":         "number",
-                    "comment":      "If 'max' is not specified the minimum value is the maximum numeric value which can be represented by the type."
-                },
-                "increment": {
-                    "description":  "Increment to use for user facing UI which increments a value",
-                    "type":         "number"
-                },
-                "rebootRequired": {
-                    "description":  "true: Vehicle must be rebooted if this value is changed",
-                    "type":         "boolean",
-                    "default":      false
-                },
-                "group": {
-                    "description":  "User readable name for a group of parameters which are commonly modified together. For example a GCS can shows params in a hierarchical display based on group ",
-                    "type":         "string",
-                    "default":      ""
-                },
-                "category": {
-                    "description":  "User readable name for a 'type' of parameter. For example 'Developer', 'System', or 'Advanced'.",
-                    "type":         "string",
-                    "default":      ""
-                },
-                "volatile": {
-                    "description":  "true: value is volatile. Should not be included in creation of a CRC over param values for example.",
-                    "type":         "boolean",
-                    "default":      false
-                },
-                "values": {
-                    "description":  "Array of values and textual descriptions for use by GCS ui.",
-                    "type":         "array",
-                    "properties": {
-                        "value": {
-                            "type": "number"
-                        },
-                        "description": {
-                            "type": "string"
+            "type": "array",
+
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description":  "Parameter Name.",
+                        "type":         "string",
+                        "pattern":      "^[\\.\\-a-zA-Z0-9_\\{\\}]{1,16}$",
+                        "comment":      "FOO{n}_BAR for name will match actual name of FOO1_BAR, FOO3_BAR and so forth." 
+                    },
+                    "type": {
+                        "description":  "Parameter type.",
+                        "type":         "string",
+                        "enum":         [ "Uint8", "Int8", "Uint16", "Int16", "Uint32", "Int32", "Float" ]
+                    },
+                    "shortDesc": {
+                        "description":  "Short user facing description/name for parameter. Used in UI intead of internal parameter name.",
+                        "type":         "string",
+                        "default":      "",
+                        "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'." 
+                    },
+                    "longDesc": {
+                        "description":  "Long user facing documentation of how the parameters works.",
+                        "type":         "string",
+                        "default":      "",
+                        "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'." 
+                    },
+                    "units": {
+                        "description":  "Units for parameter value.",
+                        "type":         "string",
+                        "default":      "",
+                        "comment":      "A 'Known Unit' allows a GCS to convert between units like meters to feet as needed. Known Units are: 'm/meter/meter', 'vertical m' - vertical distance, 'cm/px', 'm/s', 'C' - celcius, 'm^2', 'g' - grams, 'centi-degrees', 'radians', 'norm'."
+                    },
+                    "default": {
+                        "description":  "Default value for parameter.",
+                        "type":         "number",
+                        "comment":      "If a defaultValue is not specified, there is no default for the parameter available at all. A GCS should not provide an option to reset this parameter to default."
+                    },
+                    "decimalPlaces": {
+                        "description":  "Number of decimal places to show for user facing display.",
+                        "type":         "integer",
+                        "minimum":      0,
+                        "default":      7
+                    },
+                    "min": {
+                        "description":  "Minimum valid value",
+                        "type":         "number",
+                        "comment":      "If 'min' is not specified the minimum value is the minimum numeric value which can be represented by the type."
+                    },
+                    "max": {
+                        "description":  "Maximum valid value",
+                        "type":         "number",
+                        "comment":      "If 'max' is not specified the minimum value is the maximum numeric value which can be represented by the type."
+                    },
+                    "increment": {
+                        "description":  "Increment to use for user facing UI which increments a value",
+                        "type":         "number"
+                    },
+                    "rebootRequired": {
+                        "description":  "true: Vehicle must be rebooted if this value is changed",
+                        "type":         "boolean",
+                        "default":      false
+                    },
+                    "group": {
+                        "description":  "User readable name for a group of parameters which are commonly modified together. For example a GCS can shows params in a hierarchical display based on group ",
+                        "type":         "string",
+                        "default":      ""
+                    },
+                    "category": {
+                        "description":  "User readable name for a 'type' of parameter. For example 'Developer', 'System', or 'Advanced'.",
+                        "type":         "string",
+                        "default":      ""
+                    },
+                    "volatile": {
+                        "description":  "true: value is volatile. Should not be included in creation of a CRC over param values for example.",
+                        "type":         "boolean",
+                        "default":      false
+                    },
+                    "values": {
+                        "description":  "Array of values and textual descriptions for use by GCS ui.",
+                        "type":         "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "number"
+                                },
+                                "description": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "bitmask": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "index": {
+                                    "type": "integer"
+                                },
+                                "description": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
-                }
-            },
-            "required":             [ "name", "type" ],
-            "additionalProperties": false
+                },
+                "required":             [ "name", "type" ],
+                "additionalProperties": false
+            }
         }
     },
-    "required":             [ "version", "uid", "scope", "parameters" ],
+    "required":             [ "version", "scope", "parameters" ],
     "additionalProperties": false
 }

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1477,7 +1477,7 @@
         <description>Fence vertex for an inclusion polygon (the polygon must not be self-intersecting). The vehicle must stay within this area. Minimum of 3 vertices required.
         </description>
         <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count</param>
-        <param index="2">Reserved</param>
+        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group, must be the same for all points in each polygon</param>
         <param index="3">Reserved</param>
         <param index="4">Reserved</param>
         <param index="5" label="Latitude">Latitude</param>
@@ -1499,7 +1499,7 @@
         <description>Circular fence area. The vehicle must stay inside this area.
         </description>
         <param index="1" label="Radius" units="m">Radius.</param>
-        <param index="2">Reserved</param>
+        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group</param>
         <param index="3">Reserved</param>
         <param index="4">Reserved</param>
         <param index="5" label="Latitude">Latitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4515,6 +4515,7 @@
       <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>
     </message>
     <message id="234" name="HIGH_LATENCY">
+      <deprecated since="2020-10" replaced_by="HIGH_LATENCY2"/>
       <description>Message appropriate for high latency connections like Iridium</description>
       <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">Bitmap of enabled system modes.</field>
       <field type="uint32_t" name="custom_mode" display="bitmask">A bitfield for use for autopilot-specific flags.</field>


### PR DESCRIPTION
> common.xml: Mark HIGH_LATENCY as deprecated by HIGH_LATENCY2 (mavlink#1505)

According to git grep and https://github.com/ArduPilot/ardupilot/issues/7341 none of these are implemented in ArduPilot yet. So OK to deprecate one.

> component_information: fix parameter.schema.json array type (mavlink#1519)

looks good to me

> common.xml: Add 'Inclusion Group' to fence for 'OR' fences (mavlink#1510)

@IamPete1 submitted this one upstream in mavlink#1510

>  CMake: Using find_program to find mavgen(.py) (mavlink#1485)

looks good to me
