### PR TITLE
common.xml: COMMAND_INT.autocontinue - clarify not used (#1309)

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3637,7 +3637,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the mission item.</field>
       <field type="uint8_t" name="current">Not used.</field>
-      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+      <field type="uint8_t" name="autocontinue">Not used (set 0).</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>


### PR DESCRIPTION
> COMMAND_INT.autocontinue - clarify not used (mavlink#1309)

@hamishwillee has checked that it is not used in ArduPilot

This was part of #167

@peterbarker commented there:

> I have concerns about the autocontinue flag.
> It is referenced in several other places, including rather dramatically in the MISSION_ITEM description. Saying the attribute is unused when it is clearly referenced in several other places isn't good.
> I also have concerns that we may be ignoring other implementers of the mavlink standard by blowing away the attribute. I'd be a lot more comfortable if we had a registered list of interested parties in the standard.

