### PR TITLE
ardupilotmega.xml: add MAV_CMD_DO_SEND_SCRIPT_MESSAGE

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -48,6 +48,16 @@
         <param index="6">Empty.</param>
         <param index="7">Empty.</param>
       </entry>
+      <entry value="217" name="MAV_CMD_DO_SEND_SCRIPT_MESSAGE" hasLocation="false" isDestination="false">
+        <description>Pass instructions onto scripting, a script should be checking for a new command</description>
+        <param index="1" label="ID" minValue="0" maxValue="65535" increment="1">uint16 ID value to be passed to scripting</param>
+        <param index="2" label="param 1">float value to be passed to scripting</param>
+        <param index="3" label="param 2">float value to be passed to scripting</param>
+        <param index="4" label="param 3">float value to be passed to scripting</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
       <entry value="218" name="MAV_CMD_DO_AUX_FUNCTION">
         <description>Execute auxiliary function</description>
         <param index="1" label="AuxiliaryFunction">Auxiliary Function.</param>


### PR DESCRIPTION
Adds a command for use in missions to trigger scripting actions

We could potentially use all 7 params, I didn't want to confuse matters with the different types.

Or we could include a location 