### PR TITLE
add MAV_CMD_DO_ADSB_OUT_IDENT

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1567,6 +1567,16 @@
         <param index="7">Reserved (set to 0)</param>
       </entry>
       <!-- END of UAVCAN range -->
+      <entry value="10001" name="MAV_CMD_DO_ADSB_OUT_IDENT" hasLocation="false" isDestination="false">
+        <description>Trigger the start of an ADSB-out IDENT. This should only be used when requested to do so by an Air Traffic Controller in controlled airspace. This starts the IDENT which is then typically held for 18 seconds by the hardware per the Mode A, C, and S transponder spec.</description>
+        <param index="1">Reserved (set to 0)</param>
+        <param index="2">Reserved (set to 0)</param>
+        <param index="3">Reserved (set to 0)</param>
+        <param index="4">Reserved (set to 0)</param>
+        <param index="5">Reserved (set to 0)</param>
+        <param index="6">Reserved (set to 0)</param>
+        <param index="7">Reserved (set to 0)</param>
+      </entry>
       <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
       <!-- BEGIN of payload range (30000 to 30999) -->
       <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY" hasLocation="true" isDestination="true">


### PR DESCRIPTION
Add new MAV_CMD_DO_ADSB_OUT_IDENT to trigger an ADSB/ModeA/C/S Transponder IDENT.

The number 10001 was chosen because the uAvionix.xml file uses 10000-10099 but there's no MAV_CMDs in there. This was originally in that file but I pulled it out to common.xml. I think the same number is still OK to use though since it's not a msg_id.