### PR TITLE
ardupilotmega: add MAV_CMD_SET_EKF_SOURCE_SET

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -141,6 +141,16 @@
         <param index="7">Empty.</param>
       </entry>
       <!-- 42006 MAV_CMD_FIXED_MAG_CAL_YAW moved to common.xml -->
+      <entry value="42007" name="MAV_CMD_SET_EKF_SOURCE_SET" hasLocation="false" isDestination="false">
+        <description>Set EKF sensor source set.</description>
+        <param index="1" label="SourceSetId" minValue="1" maxValue="3" increment="1">Source Set Id.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
       <entry value="42424" name="MAV_CMD_DO_START_MAG_CAL" hasLocation="false" isDestination="false">
         <description>Initiate a magnetometer calibration.</description>
         <param index="1" label="Magnetometers Bitmask" minValue="0" maxValue="255" increment="1">Bitmask of magnetometers to calibrate. Use 0 to calibrate all sensors that can be started (sensors may not start if disabled, unhealthy, etc.). The command will NACK if calibration does not start for a sensor explicitly specified by the bitmask.</param>


### PR DESCRIPTION
This command allows an external system to set the EKF sensor source.  Instead of individually specifying which sensor should be used, the caller selects from 3 pre-defined (but configurable) sets (aka groups)

I think the only question is whether we want the mavlink command to accept the source set in the range 1 to 3 (to match the EK3_SRCx_ parameters) or 0 to 2 (to match the ahrs interface). Currently it is implemented in the 1 to 3 range.

ArduPilot GPS/Non-GPS Transitions wiki page: https://ardupilot.org/copter/docs/common-non-gps-to-gps.html
