### PR TITLE
common: added voltage and current multipliers to BATTERY_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4615,6 +4615,8 @@
       <field type="uint16_t[4]" name="voltages_ext" units="mV">Battery voltages for cells 11 to 14. Cells above the valid cell count for this battery should have a value of 0, where zero indicates not supported (note, this is different than for the voltages field and allows empty byte truncation). If the measured value is 0 then 1 should be sent instead.</field>
       <field type="uint8_t" name="mode" enum="MAV_BATTERY_MODE">Battery mode. Default (0) is that battery mode reporting is not supported or battery is in normal-use mode.</field>
       <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health indications. These should be set when charge_state is MAV_BATTERY_CHARGE_STATE_FAILED or MAV_BATTERY_CHARGE_STATE_UNHEALTHY (if not, fault reporting is not supported).</field>
+      <field type="uint8_t" name="volt_mult">Multiplier which should be applied to voltages in this packet to allow for higher than 65.5V. A value of 0 means no scaling</field>
+      <field type="uint8_t" name="amp_mult">Multiplier which should be applied to currents in this packet to allow for higher than 327A. A value of 0 means no scaling</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software. This should be emitted in response to a request with MAV_CMD_REQUEST_MESSAGE.</description>


### PR DESCRIPTION
this is to allow for vehicles with very high voltage and very high
current power systems. Vehicles with more than 65V ESCs are becoming
quite common