### PR TITLE
message_definitions: update message definitions from upstream

### DIFF
--- a/message_definitions/v1.0/AVSSUAS.xml
+++ b/message_definitions/v1.0/AVSSUAS.xml
@@ -3,16 +3,16 @@
 <!-- AVSS is first commercially available products are parachute recovery systems for commercial drones. -->
 <!-- AVSS contact info: -->
 <!-- company URL: https://www.avss.co -->
-<!-- email contact: josh.boudreau@avss.co thomas.li@avss.co-->
+<!-- email contact: josh.boudreau@avss.co thomas.li@avss.co llxxgg@gmail.com-->
 <!-- mavlink messenger ID range: 60050 - 60099,  mavlink command ID range: 60050 - 60099-->
 <mavlink>
   <include>common.xml</include>
-  <version>1</version>
+  <version>2</version>
   <dialect>1</dialect>
   <enums>
     <enum name="MAV_CMD">
       <!-- AVSS specific MAV_CMD_PRS* commands -->
-      <entry value="60050" name="MAV_CMD_PRS_SET_ARM" hasLocation="false" isDestination="false">
+      <entry name="MAV_CMD_PRS_SET_ARM" value="60050" isDestination="false" hasLocation="false">
         <description>AVSS defined command. Set PRS arm statuses.</description>
         <param index="1" label="ARM status">PRS arm statuses</param>
         <param index="2">User defined</param>
@@ -22,7 +22,7 @@
         <param index="6">User defined</param>
         <param index="7">User defined</param>
       </entry>
-      <entry value="60051" name="MAV_CMD_PRS_GET_ARM" hasLocation="false" isDestination="false">
+      <entry name="MAV_CMD_PRS_GET_ARM" value="60051" isDestination="false" hasLocation="false">
         <description>AVSS defined command. Gets PRS arm statuses</description>
         <param index="1">User defined</param>
         <param index="2">User defined</param>
@@ -32,7 +32,7 @@
         <param index="6">User defined</param>
         <param index="7">User defined</param>
       </entry>
-      <entry value="60052" name="MAV_CMD_PRS_GET_BATTERY" hasLocation="false" isDestination="false">
+      <entry name="MAV_CMD_PRS_GET_BATTERY" value="60052" isDestination="false" hasLocation="false">
         <description>AVSS defined command.  Get the PRS battery voltage in millivolts</description>
         <param index="1">User defined</param>
         <param index="2">User defined</param>
@@ -42,7 +42,7 @@
         <param index="6">User defined</param>
         <param index="7">User defined</param>
       </entry>
-      <entry value="60053" name="MAV_CMD_PRS_GET_ERR" hasLocation="false" isDestination="false">
+      <entry name="MAV_CMD_PRS_GET_ERR" value="60053" isDestination="false" hasLocation="false">
         <description>AVSS defined command. Get the PRS error statuses.</description>
         <param index="1">User defined</param>
         <param index="2">User defined</param>
@@ -52,7 +52,7 @@
         <param index="6">User defined</param>
         <param index="7">User defined</param>
       </entry>
-      <entry value="60070" name="MAV_CMD_PRS_SET_ARM_ALTI" hasLocation="false" isDestination="false">
+      <entry name="MAV_CMD_PRS_SET_ARM_ALTI" value="60070" isDestination="false" hasLocation="false">
         <description>AVSS defined command. Set the ATS arming altitude in meters.</description>
         <param index="1" label="Altitude" units="m">ATS arming altitude</param>
         <param index="2">User defined</param>
@@ -62,7 +62,7 @@
         <param index="6">User defined</param>
         <param index="7">User defined</param>
       </entry>
-      <entry value="60071" name="MAV_CMD_PRS_GET_ARM_ALTI" hasLocation="false" isDestination="false">
+      <entry name="MAV_CMD_PRS_GET_ARM_ALTI" value="60071" isDestination="false" hasLocation="false">
         <description>AVSS defined command. Get the ATS arming altitude in meters.</description>
         <param index="1">User defined</param>
         <param index="2">User defined</param>
@@ -72,68 +72,8 @@
         <param index="6">User defined</param>
         <param index="7">User defined</param>
       </entry>
-      <entry value="60072" name="MAV_CMD_PRS_SHUTDOWN" hasLocation="false" isDestination="false">
+      <entry name="MAV_CMD_PRS_SHUTDOWN" value="60072" isDestination="false" hasLocation="false">
         <description>AVSS defined command. Shuts down the PRS system.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="60073" name="MAV_CMD_PRS_SET_CHARGE_MV" hasLocation="false" isDestination="false">
-        <description>AVSS defined command. Set the threshold to charge from outside in millivolts</description>
-        <param index="1" label="Charge Threshold" units="mV">Charge Threshold</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="60074" name="MAV_CMD_PRS_GET_CHARGE_MV" hasLocation="false" isDestination="false">
-        <description>AVSS defined command. Get the threshold to charge from outside in millivolts.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="60075" name="MAV_CMD_PRS_SET_TIMEOUT" hasLocation="false" isDestination="false">
-        <description>AVSS defined command. Set the timeout between FTS request and deploying the chute.</description>
-        <param index="1" label="Timeout" units="ms">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="60076" name="MAV_CMD_PRS_GET_TIMEOUT" hasLocation="false" isDestination="false">
-        <description>AVSS defined command. Get the timeout between FTS request and deploying the chute.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="60077" name="MAV_CMD_PRS_SET_FTS_CONNECT" hasLocation="false" isDestination="false">
-        <description>AVSS defined command. Set up the PRS to connect to the drone..</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="60078" name="MAV_CMD_PRS_GET_FTS_CONNECT" hasLocation="false" isDestination="false">
-        <description>AVSS defined command. Get the connection status of PRS and drone.</description>
         <param index="1">User defined</param>
         <param index="2">User defined</param>
         <param index="3">User defined</param>
@@ -144,25 +84,115 @@
       </entry>
     </enum>
     <enum name="MAV_AVSS_COMMAND_FAILURE_REASON">
-      <entry value="1" name="PRS_NOT_STEADY" hasLocation="false" isDestination="false">
+      <entry name="PRS_NOT_STEADY" value="1">
         <description>AVSS defined command failure reason. PRS not steady.</description>
       </entry>
-      <entry value="2" name="PRS_DTM_NOT_ARMED" hasLocation="false" isDestination="false">
+      <entry name="PRS_DTM_NOT_ARMED" value="2">
         <description>AVSS defined command failure reason. PRS DTM not armed.</description>
       </entry>
-      <entry value="3" name="PRS_OTM_NOT_ARMED" hasLocation="false" isDestination="false">
+      <entry name="PRS_OTM_NOT_ARMED" value="3">
         <description>AVSS defined command failure reason. PRS OTM not armed.</description>
+      </entry>
+    </enum>
+    <enum name="AVSS_M300_OPERATION_MODE">
+      <entry name="MODE_M300_MANUAL_CTRL" value="0">
+        <description>In manual control mode</description>
+      </entry>
+      <entry name="MODE_M300_ATTITUDE" value="1">
+        <description>In attitude mode </description>
+      </entry>
+      <entry name="MODE_M300_P_GPS" value="6">
+        <description>In GPS mode</description>
+      </entry>
+      <entry name="MODE_M300_HOTPOINT_MODE " value="9">
+        <description>In hotpoint mode </description>
+      </entry>
+      <entry name="MODE_M300_ASSISTED_TAKEOFF" value="10">
+        <description>In assisted takeoff mode</description>
+      </entry>
+      <entry name="MODE_M300_AUTO_TAKEOFF" value="11">
+        <description>In auto takeoff mode</description>
+      </entry>
+      <entry name="MODE_M300_AUTO_LANDING" value="12">
+        <description>In auto landing mode</description>
+      </entry>
+      <entry name="MODE_M300_NAVI_GO_HOME" value="15">
+        <description>In go home mode</description>
+      </entry>
+      <entry name="MODE_M300_NAVI_SDK_CTRL " value="17">
+        <description>In sdk control mode</description>
+      </entry>
+      <entry name="MODE_M300_S_SPORT" value="31">
+        <description>In sport mode</description>
+      </entry>
+      <entry name=" MODE_M300_FORCE_AUTO_LANDING" value="33">
+        <description>In force auto landing mode</description>
+      </entry>
+      <entry name="MODE_M300_T_TRIPOD" value="38">
+        <description>In tripod mode</description>
+      </entry>
+      <entry name="MODE_M300_SEARCH_MODE" value="40">
+        <description>In search mode</description>
+      </entry>
+      <entry name="MODE_M300_ENGINE_START" value="41">
+        <description>In engine mode</description>
+      </entry>
+    </enum>
+    <enum name="AVSS_HORSEFLY_OPERATION_MODE">
+      <entry name="MODE_HORSEFLY_MANUAL_CTRL" value="0">
+        <description>In manual control mode</description>
+      </entry>
+      <entry name="MODE_HORSEFLY_AUTO_TAKEOFF" value="1">
+        <description>In auto takeoff mode</description>
+      </entry>
+      <entry name="MODE_HORSEFLY_AUTO_LANDING" value="2">
+        <description>In auto landing mode</description>
+      </entry>
+      <entry name="MODE_HORSEFLY_NAVI_GO_HOME" value="3">
+        <description>In go home mode</description>
+      </entry>
+      <entry name="MODE_HORSEFLY_DROP" value="4">
+        <description>In drop mode</description>
       </entry>
     </enum>
   </enums>
   <messages>
-    <message id="60050" name="AVSS_PRS_SYS_STATUS">
+    <message name="AVSS_PRS_SYS_STATUS" id="60050">
       <description> AVSS PRS system status.</description>
-      <field type="uint8_t" name="arm_status">PRS arm statuses</field>
-      <field type="uint16_t" name="battery_status">Estimated battery run-time without a remote connection and PRS battery voltage</field>
-      <field type="uint32_t" name="error_status">PRS error statuses</field>
-      <field type="uint8_t" name="change_status">PRS battery change statuses</field>
-      <field type="uint32_t" name="time_boot_ms">Time since PRS system boot</field>
+      <field name="time_boot_ms" units="ms" type="uint32_t">Timestamp (time since PRS boot).</field>
+      <field name="error_status" type="uint32_t">PRS error statuses</field>
+      <field name="battery_status" type="uint32_t">Estimated battery run-time without a remote connection and PRS battery voltage</field>
+      <field name="arm_status" type="uint8_t">PRS arm statuses</field>
+      <field name="charge_status" type="uint8_t">PRS battery charge statuses</field>
+    </message>
+    <message name="AVSS_DRONE_POSITION" id="60051">
+      <description> Drone position.</description>
+      <field name="time_boot_ms" units="ms" type="uint32_t">Timestamp (time since FC boot).</field>
+      <field name="lat" units="degE7" type="int32_t">Latitude, expressed</field>
+      <field name="lon" units="degE7" type="int32_t">Longitude, expressed</field>
+      <field name="alt" units="mm" type="int32_t">Altitude (MSL). Note that virtually all GPS modules provide both WGS84 and MSL.</field>
+      <field name="ground_alt" units="m" type="float">Altitude above ground, This altitude is measured by a ultrasound, Laser rangefinder or millimeter-wave radar</field>
+      <field name="barometer_alt" units="m" type="float">This altitude is measured by a barometer</field>
+    </message>
+    <message name="AVSS_DRONE_IMU" id="60052">
+      <description> Drone IMU data. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+      <field name="time_boot_ms" units="ms" type="uint32_t">Timestamp (time since FC boot).</field>
+      <field name="q1" type="float">Quaternion component 1, w (1 in null-rotation)</field>
+      <field name="q2" type="float">Quaternion component 2, x (0 in null-rotation)</field>
+      <field name="q3" type="float">Quaternion component 3, y (0 in null-rotation)</field>
+      <field name="q4" type="float">Quaternion component 4, z (0 in null-rotation)</field>
+      <field name="xacc" units="m/s/s" type="float">X acceleration</field>
+      <field name="yacc" units="m/s/s" type="float">Y acceleration</field>
+      <field name="zacc" units="m/s/s" type="float">Z acceleration</field>
+      <field name="xgyro" units="rad/s" type="float">Angular speed around X axis</field>
+      <field name="ygyro" units="rad/s" type="float">Angular speed around Y axis</field>
+      <field name="zgyro" units="rad/s" type="float">Angular speed around Z axis</field>
+    </message>
+    <message name="AVSS_DRONE_OPERATION_MODE" id="60053">
+      <description> Drone operation mode.</description>
+      <field name="time_boot_ms" units="ms" type="uint32_t">Timestamp (time since FC boot).</field>
+      <field name="M300_operation_mode" type="uint8_t">DJI M300 operation mode</field>
+      <field name="horsefly_operation_mode" type="uint8_t">horsefly operation mode</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/AVSSUAS.xml
+++ b/message_definitions/v1.0/AVSSUAS.xml
@@ -125,7 +125,7 @@
       <entry name="MODE_M300_S_SPORT" value="31">
         <description>In sport mode</description>
       </entry>
-      <entry name=" MODE_M300_FORCE_AUTO_LANDING" value="33">
+      <entry name="MODE_M300_FORCE_AUTO_LANDING" value="33">
         <description>In force auto landing mode</description>
       </entry>
       <entry name="MODE_M300_T_TRIPOD" value="38">

--- a/message_definitions/v1.0/AVSSUAS.xml
+++ b/message_definitions/v1.0/AVSSUAS.xml
@@ -104,7 +104,7 @@
       <entry name="MODE_M300_P_GPS" value="6">
         <description>In GPS mode</description>
       </entry>
-      <entry name="MODE_M300_HOTPOINT_MODE " value="9">
+      <entry name="MODE_M300_HOTPOINT_MODE" value="9">
         <description>In hotpoint mode </description>
       </entry>
       <entry name="MODE_M300_ASSISTED_TAKEOFF" value="10">
@@ -119,7 +119,7 @@
       <entry name="MODE_M300_NAVI_GO_HOME" value="15">
         <description>In go home mode</description>
       </entry>
-      <entry name="MODE_M300_NAVI_SDK_CTRL " value="17">
+      <entry name="MODE_M300_NAVI_SDK_CTRL" value="17">
         <description>In sdk control mode</description>
       </entry>
       <entry name="MODE_M300_S_SPORT" value="31">

--- a/message_definitions/v1.0/storm32.xml
+++ b/message_definitions/v1.0/storm32.xml
@@ -9,7 +9,7 @@ Range of IDs:
   commands: 60000 - 60049
 Documentation:  
   STORM32 and QSHOT additions
-  4. Feb. 2021
+  6. Okt. 2021
   All messages are technically WIP, but some are quite stable now.
   Quite stable means that it is in practical use, but may see extension.
   A more detailed description of the concept underlying the STORM32 and QSHOT messages can be found here:
@@ -59,6 +59,59 @@ Documentation:
       </entry>
       <entry value="209" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED9">
         <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+    </enum>
+    <!-- ***************************
+    STORM32 gimbal prearm check flags
+    *************************** -->
+    <enum name="MAV_STORM32_GIMBAL_PREARM_FLAGS" bitmask="true">
+      <!-- Quite stable -->
+      <description>STorM32 gimbal prearm check flags.</description>
+      <entry value="1" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_IS_NORMAL">
+        <description>STorM32 gimbal is in normal state.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_IMUS_WORKING">
+        <description>The IMUs are healthy and working normally.</description>
+      </entry>
+      <entry value="4" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_MOTORS_WORKING">
+        <description>The motors are active and working normally.</description>
+      </entry>
+      <entry value="8" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_ENCODERS_WORKING">
+        <description>The encoders are healthy and working normally.</description>
+      </entry>
+      <entry value="16" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_VOLTAGE_OK">
+        <description>A battery voltage is applied and is in range.</description>
+      </entry>
+      <entry value="32" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_VIRTUALCHANNELS_RECEIVING">
+        <description>???.</description>
+      </entry>
+      <entry value="64" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_MAVLINK_RECEIVING">
+        <description>Mavlink messages are being received.</description>
+      </entry>
+      <entry value="128" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_STORM32LINK_QFIX">
+        <description>The STorM32Link data indicates QFix.</description>
+      </entry>
+      <entry value="256" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_STORM32LINK_WORKING">
+        <description>The STorM32Link is working.</description>
+      </entry>
+      <entry value="512" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_CAMERA_CONNECTED">
+        <description>The camera has been found and is connected.</description>
+      </entry>
+      <entry value="1024" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_AUX0_LOW">
+        <description>The signal on the AUX0 input pin is low.</description>
+      </entry>
+      <entry value="2048" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_AUX1_LOW">
+        <description>The signal on the AUX1 input pin is low.</description>
+      </entry>
+      <entry value="4096" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_NTLOGGER_WORKING">
+        <description>The NTLogger is working normally.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_CAMERA_PREARM_FLAGS" bitmask="true">
+      <!-- Quite stable -->
+      <description>STorM32 camera prearm check flags.</description>
+      <entry value="1" name="MAV_STORM32_CAMERA_PREARM_FLAGS_CONNECTED">
+        <description>The camera has been found and is connected.</description>
       </entry>
     </enum>
     <!-- ***************************
@@ -340,6 +393,9 @@ Documentation:
       <entry value="8" name="MAV_QSHOT_MODE_CABLECAM_2POINT">
         <description>Start 2-point cable cam quick shot.</description>
       </entry>
+      <entry value="9" name="MAV_QSHOT_MODE_HOME_TARGETING">
+        <description>Start gimbal tracking the home location.</description>
+      </entry>
     </enum>
     <!-- ***************************
     STORM32 and QSHOT cmds
@@ -398,10 +454,10 @@ Documentation:
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint16_t" name="flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS">Gimbal device flags currently applied.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation). The frame depends on the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag.</field>
-      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown).</field>
-      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown).</field>
-      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (the frame depends on the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN if unknown).</field>
-      <field type="float" name="yaw_absolute" units="deg">Yaw in absolute frame relative to Earth's North, north is 0 (NaN if unknown).</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (NaN if unknown).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (NaN if unknown).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (the frame depends on the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN if unknown).</field>
+      <field type="float" name="yaw_absolute" units="deg" invalid="NaN">Yaw in absolute frame relative to Earth's North, north is 0 (NaN if unknown).</field>
       <field type="uint16_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure).</field>
     </message>
     <message id="60002" name="STORM32_GIMBAL_DEVICE_CONTROL">
@@ -409,11 +465,11 @@ Documentation:
       <description>Message to a gimbal device to control its attitude. This message is to be sent from the gimbal manager to the gimbal device. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS">Gimbal device flags (UINT16_MAX to be ignored).</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (positive: roll to the right, NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (positive: tilt up, NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
+      <field type="uint16_t" name="flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS" invalid="UINT16_MAX">Gimbal device flags (UINT16_MAX to be ignored).</field>
+      <field type="float[4]" name="q" invalid="[NaN:]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, set first element to NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (positive: roll to the right, NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (positive: tilt up, NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
     </message>
     <!-- ***************************
     STORM32 gimbal manager messages
@@ -424,12 +480,12 @@ Documentation:
       <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID (component ID or 1-6 for non-MAVLink gimbal) that this gimbal manager is responsible for.</field>
       <field type="uint32_t" name="device_cap_flags" enum="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS" display="bitmask">Gimbal device capability flags.</field>
       <field type="uint32_t" name="manager_cap_flags" enum="MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS" display="bitmask">Gimbal manager capability flags.</field>
-      <field type="float" name="roll_min" units="rad">Hardware minimum roll angle (positive: roll to the right, NaN if unknown).</field>
-      <field type="float" name="roll_max" units="rad">Hardware maximum roll angle (positive: roll to the right, NaN if unknown).</field>
-      <field type="float" name="pitch_min" units="rad">Hardware minimum pitch/tilt angle (positive: tilt up, NaN if unknown).</field>
-      <field type="float" name="pitch_max" units="rad">Hardware maximum pitch/tilt angle (positive: tilt up, NaN if unknown).</field>
-      <field type="float" name="yaw_min" units="rad">Hardware minimum yaw/pan angle (positive: pan to the right, relative to the vehicle/gimbal base, NaN if unknown).</field>
-      <field type="float" name="yaw_max" units="rad">Hardware maximum yaw/pan angle (positive: pan to the right, relative to the vehicle/gimbal base, NaN if unknown).</field>
+      <field type="float" name="roll_min" units="rad" invalid="NaN">Hardware minimum roll angle (positive: roll to the right, NaN if unknown).</field>
+      <field type="float" name="roll_max" units="rad" invalid="NaN">Hardware maximum roll angle (positive: roll to the right, NaN if unknown).</field>
+      <field type="float" name="pitch_min" units="rad" invalid="NaN">Hardware minimum pitch/tilt angle (positive: tilt up, NaN if unknown).</field>
+      <field type="float" name="pitch_max" units="rad" invalid="NaN">Hardware maximum pitch/tilt angle (positive: tilt up, NaN if unknown).</field>
+      <field type="float" name="yaw_min" units="rad" invalid="NaN">Hardware minimum yaw/pan angle (positive: pan to the right, relative to the vehicle/gimbal base, NaN if unknown).</field>
+      <field type="float" name="yaw_max" units="rad" invalid="NaN">Hardware maximum yaw/pan angle (positive: pan to the right, relative to the vehicle/gimbal base, NaN if unknown).</field>
     </message>
     <message id="60011" name="STORM32_GIMBAL_MANAGER_STATUS">
       <!-- Quite stable, may grow however -->
@@ -447,12 +503,12 @@ Documentation:
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID of the gimbal manager to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals, send command multiple times for more than one but not all gimbals).</field>
       <field type="uint8_t" name="client" enum="MAV_STORM32_GIMBAL_MANAGER_CLIENT">Client which is contacting the gimbal manager (must be set).</field>
-      <field type="uint16_t" name="device_flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS">Gimbal device flags (UINT16_MAX to be ignored).</field>
-      <field type="uint16_t" name="manager_flags" enum="MAV_STORM32_GIMBAL_MANAGER_FLAGS">Gimbal manager flags (0 to be ignored).</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is determined by the GIMBAL_MANAGER_FLAGS_ABSOLUTE_YAW flag, NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (positive: roll to the right, NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (positive: tilt up, NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
+      <field type="uint16_t" name="device_flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS" invalid="UINT16_MAX">Gimbal device flags (UINT16_MAX to be ignored).</field>
+      <field type="uint16_t" name="manager_flags" enum="MAV_STORM32_GIMBAL_MANAGER_FLAGS" invalid="0">Gimbal manager flags (0 to be ignored).</field>
+      <field type="float[4]" name="q" invalid="[NaN:]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is determined by the GIMBAL_MANAGER_FLAGS_ABSOLUTE_YAW flag, set first element to NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (positive: roll to the right, NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (positive: tilt up, NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
     </message>
     <message id="60013" name="STORM32_GIMBAL_MANAGER_CONTROL_PITCHYAW">
       <!-- Quite stable -->
@@ -461,12 +517,12 @@ Documentation:
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID of the gimbal manager to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals, send command multiple times for more than one but not all gimbals).</field>
       <field type="uint8_t" name="client" enum="MAV_STORM32_GIMBAL_MANAGER_CLIENT">Client which is contacting the gimbal manager (must be set).</field>
-      <field type="uint16_t" name="device_flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS">Gimbal device flags (UINT16_MAX to be ignored).</field>
-      <field type="uint16_t" name="manager_flags" enum="MAV_STORM32_GIMBAL_MANAGER_FLAGS">Gimbal manager flags (0 to be ignored).</field>
-      <field type="float" name="pitch" units="rad">Pitch/tilt angle (positive: tilt up, NaN to be ignored).</field>
-      <field type="float" name="yaw" units="rad">Yaw/pan angle (positive: pan the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
-      <field type="float" name="pitch_rate" units="rad/s">Pitch/tilt angular rate (positive: tilt up, NaN to be ignored).</field>
-      <field type="float" name="yaw_rate" units="rad/s">Yaw/pan angular rate (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
+      <field type="uint16_t" name="device_flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS" invalid="UINT16_MAX">Gimbal device flags (UINT16_MAX to be ignored).</field>
+      <field type="uint16_t" name="manager_flags" enum="MAV_STORM32_GIMBAL_MANAGER_FLAGS" invalid="0">Gimbal manager flags (0 to be ignored).</field>
+      <field type="float" name="pitch" units="rad" invalid="NaN">Pitch/tilt angle (positive: tilt up, NaN to be ignored).</field>
+      <field type="float" name="yaw" units="rad" invalid="NaN">Yaw/pan angle (positive: pan the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
+      <field type="float" name="pitch_rate" units="rad/s" invalid="NaN">Pitch/tilt angular rate (positive: tilt up, NaN to be ignored).</field>
+      <field type="float" name="yaw_rate" units="rad/s" invalid="NaN">Yaw/pan angular rate (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
     </message>
     <message id="60014" name="STORM32_GIMBAL_MANAGER_CORRECT_ROLL">
       <!-- Quite stable -->
@@ -499,6 +555,17 @@ Documentation:
       <description>Information about the shot operation.</description>
       <field type="uint16_t" name="mode" enum="MAV_QSHOT_MODE">Current shot mode.</field>
       <field type="uint16_t" name="shot_state">Current state in the shot. States are specific to the selected shot mode.</field>
+    </message>
+    <!-- ***************************
+    General messages
+    *************************** -->
+    <message id="60025" name="COMPONENT_PREARM_STATUS">
+      <!-- Quite stable -->
+      <description>Message reporting the status of the prearm checks. The flags are component specific.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="enabled_flags" invalid="UINT32_MAX">Currently enabled prearm checks. 0 means no checks are being performed, UINT32_MAX means not known.</field>
+      <field type="uint32_t" name="fail_flags">Currently not passed prearm checks. 0 means all checks have been passed.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/uAvionix.xml
+++ b/message_definitions/v1.0/uAvionix.xml
@@ -6,7 +6,7 @@
   <!-- mavlink ID range: 10000 - 10099                            -->
   <include>common.xml</include>
   <enums>
-    <enum name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE">
+    <enum name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE" bitmask="true">
       <description>State flags for ADS-B transponder dynamic report</description>
       <entry value="1" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_INTENT_CHANGE"/>
       <entry value="2" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_AUTOPILOT_ENABLED"/>
@@ -14,7 +14,7 @@
       <entry value="8" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_ON_GROUND"/>
       <entry value="16" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_IDENT"/>
     </enum>
-    <enum name="UAVIONIX_ADSB_OUT_RF_SELECT">
+    <enum name="UAVIONIX_ADSB_OUT_RF_SELECT" bitmask="true">
       <description>Transceiver RF control flags for ADS-B transponder dynamic reports</description>
       <entry value="0" name="UAVIONIX_ADSB_OUT_RF_SELECT_STANDBY"/>
       <entry value="1" name="UAVIONIX_ADSB_OUT_RF_SELECT_RX_ENABLED"/>
@@ -29,7 +29,7 @@
       <entry value="4" name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX_DGPS"/>
       <entry value="5" name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX_RTK"/>
     </enum>
-    <enum name="UAVIONIX_ADSB_RF_HEALTH">
+    <enum name="UAVIONIX_ADSB_RF_HEALTH" bitmask="true">
       <description>Status flags for ADS-B transponder dynamic output</description>
       <entry value="0" name="UAVIONIX_ADSB_RF_HEALTH_INITIALIZING"/>
       <entry value="1" name="UAVIONIX_ADSB_RF_HEALTH_OK"/>


### PR DESCRIPTION
AVSUAS and storm32 I've just pulled in as-is from upstream.

Our uavionix seems to have message definitions in it which aren't upstream, @magicrub @amilcarlucas 