### PR TITLE
ArduPilot: SENSOR_OFFSETS add deprecated note

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1127,6 +1127,7 @@
   </enums>
   <messages>
     <message id="150" name="SENSOR_OFFSETS">
+      <deprecated since="2022-02" replaced_by="MAG_CAL_REPORT, Accel Parameters, and Gyro Parameters"/>
       <description>Offsets and calibrations values for hardware sensors. This makes it easier to debug the calibration process.</description>
       <field type="int16_t" name="mag_ofs_x">Magnetometer X offset.</field>
       <field type="int16_t" name="mag_ofs_y">Magnetometer Y offset.</field>


### PR DESCRIPTION
The note might need some work...

Also the deprecated field really should accept versions too.  As version is more important than date both for a user and for us when removing things. 

This field was removed in Copter-4.2