### PR TITLE
use latest mavlink definitions for MAV_ODID_ARM_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3609,10 +3609,10 @@
       </entry>
     </enum>
     <enum name="MAV_ODID_ARM_STATUS">
-      <entry value="0" name="MAV_ODID_GOOD_TO_ARM">
+      <entry value="0" name="MAV_ODID_ARM_STATUS_GOOD_TO_ARM">
         <description>Passing arming checks.</description>
       </entry>
-      <entry value="1" name="MAV_ODID_PRE_ARM_FAIL_GENERIC">
+      <entry value="1" name="MAV_ODID_ARM_STATUS_PRE_ARM_FAIL_GENERIC">
         <description>Generic arming failure, see error string for details.</description>
       </entry>
     </enum>


### PR DESCRIPTION
- MAV_ODID_GOOD_TO_ARM message have changed in the official mavlink repository some time ago in this PR https://github.com/mavlink/mavlink/pull/1883
- this was also raised in this ArduRemoteID issue https://github.com/ArduPilot/ArduRemoteID/issues/35
- other PRs will be submitted for ArduRemoteID and ArduPilot to allow the move to the new ENUMs.
