### PR TITLE
common.xml: add fuel_pressure ext. to EFI_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5236,6 +5236,7 @@
       <field type="float" name="pt_compensation">Pressure/temperature compensation</field>
       <extensions/>
       <field type="float" name="ignition_voltage" units="V">Supply voltage to EFI sparking system.  Zero in this value means "unknown", so if the supply voltage really is zero volts use 0.0001 instead.</field>
+      <field type="float" name="fuel_pressure" units="kPa">Fuel pressure. Zero in this value means "unknown", so if the fuel pressure really is zero kPa use 0.0001 instead.</field>
     </message>
     <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
     <message id="230" name="ESTIMATOR_STATUS">


### PR DESCRIPTION
Add support for reporting fuel pressure in the `EFI_STATUS` message. Fuel pressure is already measured and logged by multiple EFI backends, and it can be a useful measurement to report to the GCS for diagnosing problems on the ground.

kPa chosen as the unit to match the two other pressure fields in the message, though this is a departure from other pressure fields in other messages.

We could potentially add other missing fields at this time too, but this one is the most useful.