### PR TITLE
common.xml: add remote id system failure to MAV_ODID_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3373,6 +3373,9 @@
       <entry value="3" name="MAV_ODID_STATUS_EMERGENCY">
         <description>The UA is having an emergency.</description>
       </entry>
+      <entry value="4" name="MAV_ODID_STATUS_REMOTE_ID_SYSTEM_FAILURE">
+        <description>The remote ID system is failing or unreliable in some way.</description>
+      </entry>
     </enum>
     <enum name="MAV_ODID_HEIGHT_REF">
       <entry value="0" name="MAV_ODID_HEIGHT_REF_OVER_TAKEOFF">


### PR DESCRIPTION
Add missing MAV_ODID_STATUS entry.

- Remote ID System Failure
- Value 4
- Defined here: https://mavlink.io/en/messages/common.html#MAV_ODID_STATUS_REMOTE_ID_SYSTEM_FAILURE

Fixes issue #299