### PR TITLE
OV3-567 Hirth: 3 new mavlink message fields

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5243,6 +5243,9 @@
       <extensions/>
       <field type="float" name="ignition_voltage" units="V">Supply voltage to EFI sparking system.  Zero in this value means "unknown", so if the supply voltage really is zero volts use 0.0001 instead.</field>
       <field type="float" name="fuel_pressure" units="kPa">Fuel pressure. Zero in this value means "unknown", so if the fuel pressure really is zero kPa use 0.0001 instead.</field>
+      <field type="float" name="cylinder_head_temperature2" units="degC">Cylinder head temperature2</field>
+      <field type="float" name="exhaust_gas_temperature2" units="degC">Exhaust gas temperature2</field>
+      <field type="uint32_t" name="System_time_in_ms" units="degC">System Time (ms)</field>
     </message>
     <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
     <message id="230" name="ESTIMATOR_STATUS">


### PR DESCRIPTION
As required by the flight team and Mechanical team, the following fields are included :
 - CHT2 (cylinder_head_temperature2)
 - EGT2 (exhaust_gas_temperature2)

Also, the following field is included for aircraft performance monitoring
 - System_time_in_ms