### PR TITLE
common.xml: remove MAV_CMD_ACK

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2037,36 +2037,6 @@
         <description>Point toward of given id.</description>
       </entry>
     </enum>
-    <enum name="MAV_CMD_ACK">
-      <description>ACK / NACK / ERROR values as a result of MAV_CMDs and for mission item transmission.</description>
-      <entry value="0" name="MAV_CMD_ACK_OK">
-        <description>Command / mission item is ok.</description>
-      </entry>
-      <entry value="1" name="MAV_CMD_ACK_ERR_FAIL">
-        <description>Generic error message if none of the other reasons fails or if no detailed error reporting is implemented.</description>
-      </entry>
-      <entry value="2" name="MAV_CMD_ACK_ERR_ACCESS_DENIED">
-        <description>The system is refusing to accept this command from this source / communication partner.</description>
-      </entry>
-      <entry value="3" name="MAV_CMD_ACK_ERR_NOT_SUPPORTED">
-        <description>Command or mission item is not supported, other commands would be accepted.</description>
-      </entry>
-      <entry value="4" name="MAV_CMD_ACK_ERR_COORDINATE_FRAME_NOT_SUPPORTED">
-        <description>The coordinate frame of this command / mission item is not supported.</description>
-      </entry>
-      <entry value="5" name="MAV_CMD_ACK_ERR_COORDINATES_OUT_OF_RANGE">
-        <description>The coordinate frame of this command is ok, but he coordinate values exceed the safety limits of this system. This is a generic error, please use the more specific error messages below if possible.</description>
-      </entry>
-      <entry value="6" name="MAV_CMD_ACK_ERR_X_LAT_OUT_OF_RANGE">
-        <description>The X or latitude value is out of range.</description>
-      </entry>
-      <entry value="7" name="MAV_CMD_ACK_ERR_Y_LON_OUT_OF_RANGE">
-        <description>The Y or longitude value is out of range.</description>
-      </entry>
-      <entry value="8" name="MAV_CMD_ACK_ERR_Z_ALT_OUT_OF_RANGE">
-        <description>The Z or altitude value is out of range.</description>
-      </entry>
-    </enum>
     <enum name="MAV_PARAM_TYPE">
       <description>Specifies the datatype of a MAVLink parameter.</description>
       <entry value="1" name="MAV_PARAM_TYPE_UINT8">


### PR DESCRIPTION
This starts off looking very much like MAV_RESULT but then starts to differ

Based off the name, remove this entirely so implementers are forced to move to MAV_RESULT.

For reference, here's MAV_RESULT, which is what CMD_ACK actually uses as an enumeration for its value field:
```
    <enum name="MAV_RESULT">
      <description>Result from a MAVLink command (MAV_CMD)</description>
      <entry value="0" name="MAV_RESULT_ACCEPTED">
        <description>Command is valid (is supported and has valid parameters), and was executed.</description>
      </entry>
      <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
        <description>Command is valid, but cannot be executed at this time. This is used to indicate a problem that should be fixed just by waiting (e.g. a state machine is busy, can't arm because have not got GPS lock, etc.). Retrying later should work.</description>
      </entry>
      <entry value="2" name="MAV_RESULT_DENIED">
        <description>Command is invalid (is supported but has invalid parameters). Retrying same command and parameters will not work.</description>
      </entry>
      <entry value="3" name="MAV_RESULT_UNSUPPORTED">
        <description>Command is not supported (unknown).</description>
      </entry>
      <entry value="4" name="MAV_RESULT_FAILED">
        <description>Command is valid, but execution has failed. This is used to indicate any non-temporary or unexpected problem, i.e. any problem that must be fixed before the command can succeed/be retried. For example, attempting to write a file when out of memory, attempting to arm when sensors are not calibrated, etc.</description>
      </entry>
      <entry value="5" name="MAV_RESULT_IN_PROGRESS">
        <description>Command is valid and is being executed. This will be followed by further progress updates, i.e. the component may send further COMMAND_ACK messages with result MAV_RESULT_IN_PROGRESS (at a rate decided by the implementation), and must terminate by sending a COMMAND_ACK message with final result of the operation. The COMMAND_ACK.progress field can be used to indicate the progress of the operation. There is no need for the sender to retry the command, but if done during execution, the component will return MAV_RESULT_IN_PROGRESS with an updated progress.</description>
      </entry>
    </enum>
```
