### PR TITLE
common: ODOMETRY add optional quality field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6105,6 +6105,7 @@
       <extensions/>
       <field type="uint8_t" name="reset_counter">Estimate reset counter. This should be incremented when the estimate resets in any of the dimensions (position, velocity, attitude, angular speed). This is designed to be used when e.g an external SLAM system detects a loop-closure and the estimate jumps.</field>
       <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Type of estimator that is providing the odometry.</field>
+      <field type="int8_t" name="quality" units="%" invalid="0">Optional odometry quality metric as a percentage. -1 = odometry has failed, 0 = unknown/unset quality, 1 = worst quality, 100 = best quality</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>


### PR DESCRIPTION
This adds the ODOMETRY quality field which is sent by the [ModalAI VOXL cameras](https://ardupilot.org/copter/docs/common-modalai-voxl.html).

Simply having this field visible in the GCS's mavlink inspectors will allow users to more easily see the quality without using ModalAI's built-in web application (which requires using a separate Wifi connection).  This also allows us to add better AP support for the camera's loss of position estimate.  As a minimum we will be able to:

1. Log the quality which will aid with support
2. refuse to fuse the position and velocity unless the quality value is above some threshold (perhaps 10%)

This has been lightly tested to confirm that AP can extract the quality field from the ODOMETRY message and that it compiles OK.

This commit is pulled directly from upstream (see https://github.com/mavlink/mavlink/pull/1861)