### PR TITLE
ardupilotmega.xml: Add FLIGHT_DURATION message

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1870,5 +1870,11 @@
       <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
       <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
     </message>
+    <message id="11045" name="FLIGHT_DURATION">
+      <description>Information about flight since last arming.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint32_t" name="arming_time_ms" units="ms" invalid="0">Timestamp at arming (time since system boot), 0 for unknown.</field>
+      <field type="uint32_t" name="takeoff_time_ms" units="ms" invalid="0">Timestamp at takeoff (time since system boot), 0 for unknown.</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Adds a new `FLIGHT_DURATION` message to report the time that the vehicle armed and took off (if known).

This message is needed if connecting a GCS to a vehicle that is already armed/flying, as otherwise these times can't be accurately determined.

This is a replacement for the existing [`FLIGHT_INFORMATION`](https://mavlink.io/en/messages/common.html#FLIGHT_INFORMATION) message, which has some issues:
* using UTC timestamps doesn't work when running simulators faster than real-time (per https://github.com/mavlink/mavlink/pull/2050);
* don't need microsecond precision on arming and takeoff times; and
* the `flight_uuid` field is unused in ArduPilot.