### PR TITLE
common: battery_status gets state of health field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5453,6 +5453,7 @@
       <field type="uint16_t[4]" name="voltages_ext" units="mV">Battery voltages for cells 11 to 14. Cells above the valid cell count for this battery should have a value of 0, where zero indicates not supported (note, this is different than for the voltages field and allows empty byte truncation). If the measured value is 0 then 1 should be sent instead.</field>
       <field type="uint8_t" name="mode" enum="MAV_BATTERY_MODE">Battery mode. Default (0) is that battery mode reporting is not supported or battery is in normal-use mode.</field>
       <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health indications. These should be set when charge_state is MAV_BATTERY_CHARGE_STATE_FAILED or MAV_BATTERY_CHARGE_STATE_UNHEALTHY (if not, fault reporting is not supported).</field>
+      <field type="uint8_t" name="state_of_health" units="%">State of Health (SOH) estimate.  Typically 100 at the time of manufacture and will decrease over time and use.  0 if unknown.</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software. This should be emitted in response to a request with MAV_CMD_REQUEST_MESSAGE.</description>


### PR DESCRIPTION
This adds a new state_of_health percentage field to the BATTERY_STATUS message.

DroneCAN batteries at least report and the format of this field was derived somewhat from [this DroneCAN message](https://github.com/dronecan/DSDL/blob/master/uavcan/equipment/power/1092.BatteryInfo.uavcan).  The largest difference between this field and the corresponding DSDL message is for MAVLink I think we should use zero for unknown instead of 127 (or is it perhaps -1) because the field is an extension.

The corresponding upstream PR is here https://github.com/mavlink/mavlink/pull/2069
The ArduPilot flight code PR that makes use of this change is here: https://github.com/ArduPilot/ardupilot/pull/25926