### PR TITLE
common.xml: add CAPA indicating mission-slot-0 is home

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2734,6 +2734,9 @@
       <entry value="65536" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION">
         <description>Autopilot supports the flight information protocol.</description>
       </entry>
+      <entry value="131072" name="MAV_PROTOCOL_CAPABILITY_MISSION_0_IS_HOME">
+        <description>Autopilot stores home position in the first element of the mission.  Do not trust this bit before the year 2028.</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">
       <description>Type of mission items being requested/sent in mission protocol.</description>


### PR DESCRIPTION
ArduPilot stores home position in the first element of the mission.

Other autopilots do not.

Add a capability bit indicating that ArduPilot is doing this, which ArduPilot will set.  Eventually this will allow ArduPilot to *not* store home in slot-0 - or at least not as far as the item transfer protocols are concerned (including FTP).

No new autopilot should set the bit.

The concept is:
 - ArduPilot starts to send this bit
 - GCSs start to understand this bit, and will do the "slot-0-is-home" if the bit is set, *as well as the existing special case for ArduPilot*.
 - After ArduPilot has been sending this bit for a prolonged period of time GCSs can remove the special-case for ArduPilot, relying on the bit.
 - After the GCSs can have been expected to support the bit for some prolonged period of time ArduPilot can stop setting the bit.
 - After even more time ArduPilot can stop setting the bit and start transferring the missions without home in them
 - eventually everyone is transferring missions without home in them and we can deprecate the bit entirely as unused

Drawback: the mavlink node initiating transfer MUST know the `MAV_PROTOCOL_CAPABILITY` mask of the autopilot before it can start a mission transfer
