### PR TITLE
ardupilotmega.xml: Add NAV_CONTROLLER_PROGRESS message

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1886,5 +1886,18 @@
       <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
       <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
     </message>
+    <message id="11045" name="NAV_CONTROLLER_PROGRESS">
+      <description>Progress of the current Nav Controller item.</description>
+      <field type="uint8_t" name="percentage_complete" invalid="UINT8_MAX">Percentage complete. Set to UINT8_MAX if unknown.</field>
+      <field type="float" name="distance_remaining" units="m" invalid="NaN">Distance remaining (in metres) until the current Nav Controller item is complete. Set to NaN if unknown, or not applicable.</field>
+      <field type="float" name="time_remaining" units="s" invalid="NaN">Time remaining (in seconds) until the current Nav Controller item is complete. Set to NaN if unknown, or not applicable.</field>
+      <field type="float" name="count_remaining" invalid="NaN">Count remaining until the current Nav Controller item is complete. Set to NaN if unknown, or not applicable.</field>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission item type.</field>
+      <field type="uint16_t" name="seq">Sequence (mission item number). Set to 0 if not a mission item.</field>
+      <field type="int32_t" name="target_x" invalid="INT32_MAX">X pos/Latitude of nav target. Set to INT32_MAX if no target, or to use the location of the corresponding mission item.</field>
+      <field type="int32_t" name="target_y" invalid="INT32_MAX">Y pos/Longitude of nav target. Set to INT32_MAX if no target, or to use the location of the corresponding mission item.</field>
+      <field type="float" name="target_z" units="m" invalid="NaN">Z pos/Altitude of nav target. Set to NaN if no target, or to use the location of the corresponding mission item.</field>
+      <field type="uint8_t" name="target_frame" enum="MAV_FRAME">Coordinate frame of target.</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Second attempt at addressing https://github.com/mavlink/mavlink/issues/2023. 

Adds a new `NAV_CONTROLLER_PROGRESS` message (per https://github.com/mavlink/mavlink/pull/2029#issuecomment-1766214285) that can be used to report the progress of the current Nav Controller item.