### PR TITLE
Remove legacy attribute: display="bitmask"

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1519,9 +1519,9 @@
       <field type="uint32_t" name="last_recovery" units="ms">Time (since boot) of last successful recovery.</field>
       <field type="uint32_t" name="last_clear" units="ms">Time (since boot) of last all-clear.</field>
       <field type="uint16_t" name="breach_count">Number of fence breaches.</field>
-      <field type="uint8_t" name="mods_enabled" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of enabled modules.</field>
-      <field type="uint8_t" name="mods_required" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of required modules.</field>
-      <field type="uint8_t" name="mods_triggered" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of triggered modules.</field>
+      <field type="uint8_t" name="mods_enabled" enum="LIMIT_MODULE">AP_Limit_Module bitfield of enabled modules.</field>
+      <field type="uint8_t" name="mods_required" enum="LIMIT_MODULE">AP_Limit_Module bitfield of required modules.</field>
+      <field type="uint8_t" name="mods_triggered" enum="LIMIT_MODULE">AP_Limit_Module bitfield of triggered modules.</field>
     </message>
     <message id="168" name="WIND">
       <description>Wind estimation.</description>
@@ -1586,7 +1586,7 @@
       <!-- Path planned landings are still in the future, but we want these fields ready: -->
       <field type="int16_t" name="break_alt" units="m">Break altitude relative to home.</field>
       <field type="uint16_t" name="land_dir" units="cdeg">Heading to aim for when landing.</field>
-      <field type="uint8_t" name="flags" enum="RALLY_FLAGS" display="bitmask">Configuration flags.</field>
+      <field type="uint8_t" name="flags" enum="RALLY_FLAGS">Configuration flags.</field>
     </message>
     <message id="176" name="RALLY_FETCH_POINT">
       <description>Request a current rally point from MAV. MAV should respond with a RALLY_POINT message. MAV should not respond if the request is invalid.</description>
@@ -1706,7 +1706,7 @@
     <message id="191" name="MAG_CAL_PROGRESS">
       <description>Reports progress of compass calibration.</description>
       <field type="uint8_t" name="compass_id" instance="true">Compass being calibrated.</field>
-      <field type="uint8_t" name="cal_mask" display="bitmask">Bitmask of compasses being calibrated.</field>
+      <field type="uint8_t" name="cal_mask">Bitmask of compasses being calibrated.</field>
       <field type="uint8_t" name="cal_status" enum="MAG_CAL_STATUS">Calibration Status.</field>
       <field type="uint8_t" name="attempt">Attempt number.</field>
       <field type="uint8_t" name="completion_pct" units="%">Completion percentage.</field>
@@ -1719,7 +1719,7 @@
     <!-- EKF status message from autopilot to GCS. -->
     <message id="193" name="EKF_STATUS_REPORT">
       <description>EKF Status message including flags and variances.</description>
-      <field type="uint16_t" name="flags" enum="EKF_STATUS_FLAGS" display="bitmask">Flags.</field>
+      <field type="uint16_t" name="flags" enum="EKF_STATUS_FLAGS">Flags.</field>
       <!-- supported flags see EKF_STATUS_FLAGS enum -->
       <field type="float" name="velocity_variance">Velocity variance.</field>
       <!-- below 0.5 is good, 0.5~0.79 is warning, 0.8 or higher is bad -->
@@ -1793,7 +1793,7 @@
       <description>Heartbeat from a HeroBus attached GoPro.</description>
       <field type="uint8_t" name="status" enum="GOPRO_HEARTBEAT_STATUS">Status.</field>
       <field type="uint8_t" name="capture_mode" enum="GOPRO_CAPTURE_MODE">Current capture mode.</field>
-      <field type="uint8_t" name="flags" enum="GOPRO_HEARTBEAT_FLAGS" display="bitmask">Additional status bits.</field>
+      <field type="uint8_t" name="flags" enum="GOPRO_HEARTBEAT_FLAGS">Additional status bits.</field>
       <!-- see GOPRO_HEARTBEAT_FLAGS -->
     </message>
     <message id="216" name="GOPRO_GET_REQUEST">

--- a/message_definitions/v1.0/uAvionix.xml
+++ b/message_definitions/v1.0/uAvionix.xml
@@ -151,7 +151,7 @@
       <field type="uint8_t" name="gpsOffsetLat" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT">GPS antenna lateral offset (table 2-36 of DO-282B)</field>
       <field type="uint8_t" name="gpsOffsetLon" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON">GPS antenna longitudinal offset from nose [if non-zero, take position (in meters) divide by 2 and add one] (table 2-37 DO-282B)</field>
       <field type="uint16_t" name="stallSpeed" units="cm/s">Aircraft stall speed in cm/s</field>
-      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT" display="bitmask">ADS-B transponder reciever and transmit enable flags</field>
+      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT">ADS-B transponder reciever and transmit enable flags</field>
     </message>
     <message id="10002" name="UAVIONIX_ADSB_OUT_DYNAMIC">
       <description>Dynamic data used to generate ADS-B out transponder data (send at 5Hz)</description>
@@ -169,12 +169,12 @@
       <field type="int16_t" name="velNS" units="cm/s">North-South velocity over ground in cm/s North +ve. If unknown set to INT16_MAX</field>
       <field type="int16_t" name="VelEW" units="cm/s">East-West velocity over ground in cm/s East +ve. If unknown set to INT16_MAX</field>
       <field type="uint8_t" name="emergencyStatus" enum="UAVIONIX_ADSB_EMERGENCY_STATUS">Emergency status</field>
-      <field type="uint16_t" name="state" enum="UAVIONIX_ADSB_OUT_DYNAMIC_STATE" display="bitmask">ADS-B transponder dynamic input state flags</field>
+      <field type="uint16_t" name="state" enum="UAVIONIX_ADSB_OUT_DYNAMIC_STATE">ADS-B transponder dynamic input state flags</field>
       <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
     </message>
     <message id="10003" name="UAVIONIX_ADSB_TRANSCEIVER_HEALTH_REPORT">
       <description>Transceiver heartbeat with health report (updated every 10s)</description>
-      <field type="uint8_t" name="rfHealth" enum="UAVIONIX_ADSB_RF_HEALTH" display="bitmask">ADS-B transponder messages</field>
+      <field type="uint8_t" name="rfHealth" enum="UAVIONIX_ADSB_RF_HEALTH">ADS-B transponder messages</field>
     </message>
     <message id="10004" name="UAVIONIX_ADSB_OUT_CFG_REGISTRATION">
       <description>Aircraft Registration.</description>
@@ -190,20 +190,20 @@
     </message>
     <message id="10007" name="UAVIONIX_ADSB_OUT_CONTROL">
       <description>Control message with all data sent in UCP control message.</description>
-      <field type="uint8_t" name="state" enum="UAVIONIX_ADSB_OUT_CONTROL_STATE" display="bitmask">ADS-B transponder control state flags</field>
+      <field type="uint8_t" name="state" enum="UAVIONIX_ADSB_OUT_CONTROL_STATE">ADS-B transponder control state flags</field>
       <field type="int32_t" name="baroAltMSL" units="mbar">Barometric pressure altitude (MSL) relative to a standard atmosphere of 1013.2 mBar and NOT bar corrected altitude (m * 1E-3). (up +ve). If unknown set to INT32_MAX</field>
       <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
       <field type="uint8_t" name="emergencyStatus" enum="UAVIONIX_ADSB_EMERGENCY_STATUS">Emergency status</field>
       <field type="char[8]" name="flight_id">Flight Identification: 8 ASCII characters, '0' through '9', 'A' through 'Z' or space. Spaces (0x20) used as a trailing pad character, or when call sign is unavailable.</field>
-      <field type="uint8_t" name="x_bit" enum="UAVIONIX_ADSB_XBIT" display="bitmask">X-Bit enable (military transponders only)</field>
+      <field type="uint8_t" name="x_bit" enum="UAVIONIX_ADSB_XBIT">X-Bit enable (military transponders only)</field>
     </message>
     <message id="10008" name="UAVIONIX_ADSB_OUT_STATUS">
       <description>Status message with information from UCP Heartbeat and Status messages.</description>
-      <field type="uint8_t" name="state" enum="UAVIONIX_ADSB_OUT_STATUS_STATE" display="bitmask">ADS-B transponder status state flags</field>
+      <field type="uint8_t" name="state" enum="UAVIONIX_ADSB_OUT_STATUS_STATE">ADS-B transponder status state flags</field>
       <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
       <field type="uint8_t" name="NIC_NACp" enum="UAVIONIX_ADSB_OUT_STATUS_NIC_NACP">Integrity and Accuracy of traffic reported as a 4-bit value for each field (NACp 7:4, NIC 3:0) and encoded by Containment Radius (HPL) and Estimated Position Uncertainty (HFOM), respectively</field>
       <field type="uint8_t" name="boardTemp">Board temperature in C</field>
-      <field type="uint8_t" name="fault" enum="UAVIONIX_ADSB_OUT_STATUS_FAULT" display="bitmask">ADS-B transponder fault flags</field>
+      <field type="uint8_t" name="fault" enum="UAVIONIX_ADSB_OUT_STATUS_FAULT">ADS-B transponder fault flags</field>
       <field type="char[8]" name="flight_id">Flight Identification: 8 ASCII characters, '0' through '9', 'A' through 'Z' or space. Spaces (0x20) used as a trailing pad character, or when call sign is unavailable.</field>
     </message>
   </messages>


### PR DESCRIPTION
This removes the `display="bitmask"` attribute on fields that reference a bitmask enum from the ArduPilot-managed dialects. I believe that to be the entire included set:

- [x] ardupilotmega.xml
- [x] uAvionix.xml
- [x] icarous.xml - None
- [x] loweheiser.xml - None
- [x] cubepilot.xml - None
- [x] csAirLink.xml - None

All the enums that use this are marked up as bitmasks using `bitmask="true"`, so the information on the field is inferable. We're heading towards removing the bitmask indication on the field itself.

History here is that `display="bitmask"` was added on request of QGC to allow auto-generation of checkbox UI. We later decided that it was better to have on the enum, because that is the thing we know is a bitmask. 
However neither attribute is actually used in QGC or Mission Planner or MAVProxy. It might be used elsewhere, but unlikely.

Upstream removes them in https://github.com/mavlink/mavlink/pull/2215

This falls out of @IamPete1 consistency checker, added in https://github.com/mavlink/mavlink/pull/2206

