### PR TITLE
mavgenerate.py: Remove support for Python 2

### DIFF
--- a/mavgenerate.py
+++ b/mavgenerate.py
@@ -24,22 +24,9 @@ import os
 import re   
 import sys
 
-# Python 2.x and 3.x compatibility
-if sys.version_info[0] == 3:
-    from tkinter import *
-    import tkinter.filedialog
-    import tkinter.messagebox
-else:
-    # Must be using Python 2.x, import and rename
-    from Tkinter import *
-    import tkFileDialog
-    import tkMessageBox
-
-    tkinter.filedialog = tkFileDialog
-    del tkFileDialog
-    tkinter.messagebox = tkMessageBox
-    del tkMessageBox
-    
+from tkinter import *
+import tkinter.filedialog
+import tkinter.messagebox
 
 from pymavlink.generator import mavgen
 from pymavlink.generator import mavparse


### PR DESCRIPTION
Replicates upstream change:
* https://github.com/mavlink/mavlink/pull/2309
* https://github.com/mavlink/mavlink/pull/2303#pullrequestreview-3003545878