### PR TITLE
actuators.schema.json: Typos in actuator-output-testing-values.properties

### DIFF
--- a/component_information/actuators.schema.json
+++ b/component_information/actuators.schema.json
@@ -17,17 +17,17 @@
             "properties": {
                 "min": {
                     "type": "number",
-                    "minium": -1,
+                    "minimum": -1,
                     "maximum": 1
                 },
                 "max": {
                     "type": "number",
-                    "minium": -1,
+                    "minimum": -1,
                     "maximum": 1
                 },
                 "default": {
                     "type": "number",
-                    "minium": -1,
+                    "minimum": -1,
                     "maximum": 1
                 },
                 "default-is-nan": {


### PR DESCRIPTION
> [!CAUTION]
> Careful review, please.  This proposed change might not be worth the risk of breakage.

The proposed modification would change a data key in `actuator-output-testing-values.properties`, which might break the reading and writing of data files elsewhere.