### PR TITLE
Fix two typos in XML files

### DIFF
--- a/message_definitions/v1.0/loweheiser.xml
+++ b/message_definitions/v1.0/loweheiser.xml
@@ -38,7 +38,7 @@
       <!-- EFI fields -->
       <field type="float" name="efi_batt" units="V"> EFI Supply Voltage.</field>
       <field type="float" name="efi_rpm" units="rpm">Motor RPM.</field>
-      <field type="float" name="efi_pw" units="ms">Injector pulse-width in miliseconds.</field>
+      <field type="float" name="efi_pw" units="ms">Injector pulse-width in milliseconds.</field>
       <field type="float" name="efi_fuel_flow">Fuel flow rate in litres/hour.</field>
       <field type="float" name="efi_fuel_consumed" units="l">Fuel consumed.</field>
       <field type="float" name="efi_baro" units="kPa">Atmospheric pressure.</field>

--- a/message_definitions/v1.0/uAvionix.xml
+++ b/message_definitions/v1.0/uAvionix.xml
@@ -149,7 +149,7 @@
       <field type="uint8_t" name="gpsOffsetLat" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT">GPS antenna lateral offset (table 2-36 of DO-282B)</field>
       <field type="uint8_t" name="gpsOffsetLon" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON">GPS antenna longitudinal offset from nose [if non-zero, take position (in meters) divide by 2 and add one] (table 2-37 DO-282B)</field>
       <field type="uint16_t" name="stallSpeed" units="cm/s">Aircraft stall speed in cm/s</field>
-      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT">ADS-B transponder reciever and transmit enable flags</field>
+      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT">ADS-B transponder receiver and transmit enable flags</field>
     </message>
     <message id="10002" name="UAVIONIX_ADSB_OUT_DYNAMIC">
       <description>Dynamic data used to generate ADS-B out transponder data (send at 5Hz)</description>


### PR DESCRIPTION
Related to:
* #401
* mavlink/mavlink#2301
* mavlink/mavlink#2311
```
./message_definitions/v1.0/loweheiser.xml:41: miliseconds ==> milliseconds
./message_definitions/v1.0/uAvionix.xml:152: reciever ==> receiver
```