### PR TITLE
Mav hierarchy is development > common > standard > minimal

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <mavlink>
-  <include>minimal.xml</include>
+  <include>standard.xml</include>
   <version>3</version>
   <dialect>0</dialect>
   <enums>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <mavlink>
-  <!-- XML file for prototyping definitions for standard.xml  -->
-  <include>standard.xml</include>
+  <!-- XML file for prototyping definitions for common.xml  -->
+  <include>common.xml</include>
   <version>0</version>
   <dialect>0</dialect>
   <enums>

--- a/message_definitions/v1.0/standard.xml
+++ b/message_definitions/v1.0/standard.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <mavlink>
   <!-- MAVLink standard messages -->
-  <include>common.xml</include>
+  <include>minimal.xml</include>
   <dialect>0</dialect>
-  <!-- use common.xml enums -->
+  <!-- use minimal.xml enums -->
   <enums/>
-  <!-- use common.xml messages -->
+  <!-- use minimal.xml messages -->
   <messages/>
 </mavlink>


### PR DESCRIPTION
Updates the include hierarchy to match upstream (precondition to make standard.xml contain standard things and work with common too).

Once integrated, #409 should build on this.