### PR TITLE
Align minimal.xml to upstream

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -200,9 +200,27 @@
       <entry value="42" name="MAV_TYPE_WINCH">
         <description>Winch</description>
       </entry>
+      <entry value="43" name="MAV_TYPE_GENERIC_MULTIROTOR">
+        <description>Generic multirotor that does not fit into a specific type or whose type is unknown</description>
+      </entry>
+      <entry value="44" name="MAV_TYPE_ILLUMINATOR">
+        <description>Illuminator. An illuminator is a light source that is used for lighting up dark areas external to the system: e.g. a torch or searchlight (as opposed to a light source for illuminating the system itself, e.g. an indicator light).</description>
+      </entry>
+      <entry value="45" name="MAV_TYPE_SPACECRAFT_ORBITER">
+        <description>Orbiter spacecraft. Includes satellites orbiting terrestrial and extra-terrestrial bodies. Follows NASA Spacecraft Classification.</description>
+      </entry>
+      <entry value="46" name="MAV_TYPE_GROUND_QUADRUPED">
+        <description>A generic four-legged ground vehicle (e.g., a robot dog).</description>
+      </entry>
+      <entry value="47" name="MAV_TYPE_VTOL_GYRODYNE">
+        <description>VTOL hybrid of helicopter and autogyro. It has a main rotor for lift and separate propellers for forward flight. The rotor must be powered for hover but can autorotate in cruise flight. See: https://en.wikipedia.org/wiki/Gyrodyne</description>
+      </entry>
+      <entry value="48" name="MAV_TYPE_GRIPPER">
+        <description>Gripper</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
-      <description>These flags encode the MAV mode.</description>
+      <description>These flags encode the MAV mode, see MAV_MODE enum for useful combinations.</description>
       <entry value="128" name="MAV_MODE_FLAG_SAFETY_ARMED">
         <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignore when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
       </entry>
@@ -272,16 +290,16 @@
         <description>System is active and might be already airborne. Motors are engaged.</description>
       </entry>
       <entry value="5" name="MAV_STATE_CRITICAL">
-        <description>System is in a non-normal flight mode. It can however still navigate.</description>
+        <description>System is in a non-normal flight mode (failsafe). It can however still navigate.</description>
       </entry>
       <entry value="6" name="MAV_STATE_EMERGENCY">
-        <description>System is in a non-normal flight mode. It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
+        <description>System is in a non-normal flight mode (failsafe). It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
       </entry>
       <entry value="7" name="MAV_STATE_POWEROFF">
         <description>System just initialized its power-down sequence, will shut down now.</description>
       </entry>
       <entry value="8" name="MAV_STATE_FLIGHT_TERMINATION">
-        <description>System is terminating itself.</description>
+        <description>System is terminating itself (failsafe or commanded).</description>
       </entry>
     </enum>
     <enum name="MAV_COMPONENT">
@@ -605,6 +623,9 @@
       <entry value="161" name="MAV_COMP_ID_PARACHUTE">
         <description>Parachute component.</description>
       </entry>
+      <entry value="169" name="MAV_COMP_ID_WINCH">
+        <description>Winch component.</description>
+      </entry>
       <entry value="171" name="MAV_COMP_ID_GIMBAL2">
         <description>Gimbal #2.</description>
       </entry>
@@ -689,9 +710,12 @@
       <entry value="242" name="MAV_COMP_ID_TUNNEL_NODE">
         <description>Component handling TUNNEL messages (e.g. vendor specific GUI of a component).</description>
       </entry>
+      <entry value="243" name="MAV_COMP_ID_ILLUMINATOR">
+        <description>Illuminator</description>
+      </entry>
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
-        <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID.</deprecated>
-        <description>Component for handling system messages (e.g. to ARM, takeoff, etc.).</description>
+        <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID. Instead, system commands should be sent with target_component=MAV_COMP_ID_ALL allowing the target component to use any appropriate component id.</deprecated>
+        <description>Deprecated, don't use. Component for handling system messages (e.g. to ARM, takeoff, etc.).</description>
       </entry>
     </enum>
   </enums>
@@ -700,7 +724,7 @@
       <description>The heartbeat message shows that a system or component is present and responding. The type and autopilot fields (along with the message component id), allow the receiving system to treat further messages from this system appropriately (e.g. by laying out the user interface based on the autopilot). This microservice is documented at https://mavlink.io/en/services/heartbeat.html</description>
       <field type="uint8_t" name="type" enum="MAV_TYPE">Vehicle or component type. For a flight controller component the vehicle type (quadrotor, helicopter, etc.). For other components the component type (e.g. camera, gimbal, etc.). This should be used in preference to component id for identifying the component type.</field>
       <field type="uint8_t" name="autopilot" enum="MAV_AUTOPILOT">Autopilot type / class. Use MAV_AUTOPILOT_INVALID for components that are not flight controllers.</field>
-      <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
+      <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG">System mode bitmap.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
       <field type="uint8_t" name="system_status" enum="MAV_STATE">System status flag.</field>
       <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>


### PR DESCRIPTION
This aligns minimal.xml to upstream. I don't see anything controversial.

The only thing I omitted is this change to an enum name, which will require a recompile. This may therefore affect mission planner and they need to be informed. Note that QGC made this change last year. Should I add that here or do as a separate PR. @peterbarker 

<img width="2157" height="291" alt="image" src="https://github.com/user-attachments/assets/d6084a62-1082-4c53-a1ae-9468d4f9cb7b" />


