### PR TITLE
Update common.xml to add units for RAW_IMU and clarify description

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4403,17 +4403,17 @@
       <field type="int16_t" name="temperature" units="cdegC">Temperature, 0: IMU does not provide temperature values. If the IMU is at 0C it must send 1 (0.01C).</field>
     </message>
     <message id="27" name="RAW_IMU">
-      <description>The RAW IMU readings for a 9DOF sensor, which is identified by the id (default IMU1). This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
+      <description>The RAW IMU readings for a 9DOF sensor, which is identified by the id (default IMU1). This message should always contain the true raw values without any scaling to allow data capture and system debugging. On ArduPilot platforms, this message is identical to SCALED_IMU. By default, only RAW_IMU is sent via telemetry for historical reasons, SCALED_IMU can be requested.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="int16_t" name="xacc">X acceleration (raw)</field>
-      <field type="int16_t" name="yacc">Y acceleration (raw)</field>
-      <field type="int16_t" name="zacc">Z acceleration (raw)</field>
-      <field type="int16_t" name="xgyro">Angular speed around X axis (raw)</field>
-      <field type="int16_t" name="ygyro">Angular speed around Y axis (raw)</field>
-      <field type="int16_t" name="zgyro">Angular speed around Z axis (raw)</field>
-      <field type="int16_t" name="xmag">X Magnetic field (raw)</field>
-      <field type="int16_t" name="ymag">Y Magnetic field (raw)</field>
-      <field type="int16_t" name="zmag">Z Magnetic field (raw)</field>
+      <field type="int16_t" name="xacc" units="mG">X acceleration (raw)</field>
+      <field type="int16_t" name="yacc" units="mG">Y acceleration (raw)</field>
+      <field type="int16_t" name="zacc" units="mG">Z acceleration (raw)</field>
+      <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis (raw)</field>
+      <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis (raw)</field>
+      <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis (raw)</field>
+      <field type="int16_t" name="xmag" units="mgauss">X Magnetic field (raw)</field>
+      <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field (raw)</field>
+      <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field (raw)</field>
       <extensions/>
       <field type="uint8_t" name="id" instance="true">Id. Ids are numbered from 0 and map to IMUs numbered from 1 (e.g. IMU1 will have a message with id=0)</field>
       <field type="int16_t" name="temperature" units="cdegC">Temperature, 0: IMU does not provide temperature values. If the IMU is at 0C it must send 1 (0.01C).</field>


### PR DESCRIPTION
After discussion with @peterbarker on the Ardupilot discord, it has become clear that the Ardupilot ``RAW_IMU`` packet is identical to `SCALED_IMU`, yet `RAW_IMU `had no units documented. 

This PR introduces units that match what Ardupilot is sending into the `RAW_IMU `description. The edits were done via the GitHub web interface with no syntax checking for the XML, though I believe it remains correct.

I think it is worthy of note though that the way Ardupilot is using the `RAW_IMU `packet stands in direct conflict with (my interpretation) of the description of what the `RAW_IMU `packet is supposed to contain. Ardupilot `RAW_IMU `data is not raw, but processed and scaled to a known unit, the one of `SCALED_IMU`.
I'd argue discussion is warranted of whether Ardupilot should continue to send `RAW_IMU `by default, or whether it should send `SCALED_IMU `by default, and only send `RAW_IMU `on request, and with actual raw data.