### PR TITLE
common.xml: specify that TUNE_FORMAT.tune is specifically MML

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5864,7 +5864,7 @@
       <description>Control vehicle tone generation (buzzer).</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[30]" name="tune">tune in board specific format</field>
+      <field type="char[30]" name="tune">Format is Modern Music Markup Language (MML): https://en.wikipedia.org/wiki/Music_Macro_Language#Modern_MML.</field>
       <extensions/>
       <field type="char[200]" name="tune2">tune extension (appended to tune)</field>
     </message>


### PR DESCRIPTION
Only MAVProxy and ArduPilot seem to support this.  And possibly something on SkyViper.

This is a *breaking change* for PX4-AutoPilot, and we must not merge this without getting the OK from them.  PX4-AutoPilot is expecting qbasic tune strings in this field.  Given that there doesn't appear to be any clients which will send QBASIC in `PLAY_TUNE`, and that clients could easily move to `PLAY_TUNE_V2`, they may be willing to accept the change.  @hamishwillee 

I've checked QGC, paparazzi, PX4-AutoPilot, MAVProxy, ardupilot, APMPlanner2.

It was a mistake to not specify the format for `PLAY_TUNE.tune` string in a standards document.  `PLAY_TUNE_V2` came out of that mistake, and was an even bigger mistake (resources are available on the ground to convert to/from a standardised input format)
