### PR TITLE
common.xml: remove MAV_CMD_DO_UPGRADE (#2469)

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1869,7 +1869,7 @@
         <param index="6" label="Conditions" enum="REBOOT_SHUTDOWN_CONDITIONS">Conditions under which reboot/shutdown is allowed.</param>
         <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
       </entry>
-      <!-- id "247" reserved for MAV_CMD_DO_UPGRADE in development.xml -->
+      <!-- id "247" was MAV_CMD_DO_UPGRADE, no publicly available code available -->
       <entry value="252" name="MAV_CMD_OVERRIDE_GOTO" hasLocation="true" isDestination="true">
         <description>Override current mission with command to pause mission, pause mission and move to position, continue/resume mission. When param 1 indicates that the mission is paused (MAV_GOTO_DO_HOLD), param 2 defines whether it holds in place or moves to another position.</description>
         <param index="1" label="Continue" enum="MAV_GOTO">MAV_GOTO_DO_HOLD: pause mission and either hold or move to specified position (depending on param2), MAV_GOTO_DO_CONTINUE: resume mission.</param>


### PR DESCRIPTION
the message was merged in 2020 and never moved out of wip / development.xml

No code in PX4-AutoPilot, ArduPilot, betaflight, paparazzi, QGC, MissionPlanner, apm_planner2


(this is a cherry-pick of a patch in mavlink/mavlink/master)
