### PR TITLE
development.xml: copy MAV_COMMAND_REQUEST_OPERATOR_CONTROL from mavlink/mavlink/master

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2836,6 +2836,10 @@
       <entry value="8" name="MAV_RESULT_COMMAND_INT_ONLY">
         <description>Command is only accepted when sent as a COMMAND_INT.</description>
       </entry>
+      <entry value="10" name="MAV_RESULT_NOT_IN_CONTROL">
+        <wip/>
+        <description>Command has been rejected because source system is not in control of the target system/component.</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">
       <description>Result of mission operation (in a MISSION_ACK message).</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -76,6 +76,62 @@
         <param index="3" label="Direction" units="deg" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
         <param index="4" label="Direction accuracy" units="deg">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
       </entry>
+      <entry value="32100" name="MAV_CMD_REQUEST_OPERATOR_CONTROL" hasLocation="false" isDestination="false">
+        <description>Request exclusive control of a system or special system feature by a GCS.
+
+          The operator control protocol supports two modes:
+          - In single-owner mode there is a single GCS "owner" that can send state changing operations to the whole system, and this command can be used to request takeover of that ownership role.
+          - In multi-owner mode the flight stack allows multiple GCS to be "owners" and send (most) state changing operations (which GCS those are is implementation-dependent, and not controlled by this protocol).
+            However only one GCS owner can control manual input of the vehicle: this command can be used to request takeover of that ownership role.
+        
+          A controlled system should only accept MAVLink operations that change the state of the vehicle, such as commands and command-like messages, which are sent by its controlling GCS(s) (or from other components in its own system/with the same system id, such as a companion computer).
+          Commands to control the vehicle from other systems should be rejected with MAV_RESULT_NOT_IN_CONTROL (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
+          Messages and commands that don't control or change vehicle movement or functionality, such as telemetry requests, may still be send from (and to) a controlled system.
+
+          GCS control of the whole system is managed via a single component that we will refer to here as the "system manager component".
+          This component streams the CONTROL_STATUS message and sets the GCS_CONTROL_STATUS_FLAGS_SYSTEM_MANAGER flag.
+          Other components in the system should monitor for the CONTROL_STATUS message with this flag, and set their controlling GCS(s) to match its published system id(s).
+          A GCS that wants to control the system should also monitor for the same message and flag, and address the MAV_CMD_REQUEST_OPERATOR_CONTROL to its component id.
+          Note that integrators are required to ensure that there is only one system manager component in the system (i.e. one component emitting the message with GCS_CONTROL_STATUS_FLAGS_SYSTEM_MANAGER set).
+
+          The MAV_CMD_REQUEST_OPERATOR_CONTROL command is sent by a GCS to the system manager component to request or release control of a system, specifying whether subsequent takeover requests from another GCS are automatically granted, or require permission.
+          The command may request control for a single GCS system ID or a range of GCS system IDs: the sender of the command must have a system id that is in the requested range.
+
+          The system manager component should grant control to the requested GCS(s) if the system does not require takeover permission (or is uncontrolled) and ACK the request with MAV_RESULT_ACCEPTED.
+          The system manager component should then stream CONTROL_STATUS indicating its controlling system(s): all other components in the system (with the same system id) should monitor this message and set their own controlling GCS(s) to match that of the system manager component.
+
+          If the system manager component cannot grant control because takeover requires permission, the request should be rejected with MAV_RESULT_FAILED.
+          The system manager component should then send this same command to the owning GCS with the lowest system ID that has a heartbeat, in order to notify of the request.
+          That owning GCS must ACK with MAV_RESULT_ACCEPTED, and may choose to release control of the vehicle, or re-request control with the takeover bit set to allow permission.
+          In case it choses to re-request control with takeover bit set to allow permission, the requester GCS will only have 10 seconds to get control, otherwise owning GCS will re-request control with takeover bit set to disallow permission, and requester GCS will need repeat the request if still interested in getting control.
+          Note that the pilots of both GCS should coordinate safe handover offline.
+
+          While any owning GCS are connected the system should consider itself connected to a GCS, and still owned by all GCS (even those that are not connected).
+          If all owning GCS are disconnected the vehicle should GCS loss failsafe, and broadcast a CONTROL_STATUS indicating that it has no owner(s).
+          In simultaneous-owner scenarios this allows an owner to disconnect and reconnect without the vehicle failsafing, provided at least one owner is connected.
+               
+          Note that in most systems the only controlled component will be the "system manager component", and that will be the autopilot (although it could be a companion computer).
+          However separate GCS control of a particular component is also permitted, if supported by the component.
+          In this case the GCS will address MAV_CMD_REQUEST_OPERATOR_CONTROL to the specific component it wants to control.
+          The component will then stream CONTROL_STATUS for its controlling GCS (it must not set GCS_CONTROL_STATUS_FLAGS_SYSTEM_MANAGER).
+          The component should fall back to the system GCS (if any) when it is not directly controlled, and may stop emitting CONTROL_STATUS.
+          The flow is otherwise the same as for requesting control over the whole system.
+        </description>
+        <param index="1" label="Action">0: Release control, 1: Request control.</param>
+        <param index="2" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>
+        <param index="3" label="Request timeout" units="s" minValue="3" maxValue="60">Timeout in seconds before a request to a GCS to allow takeover is assumed to be rejected. This is used to display the timeout graphically on requester and GCS in control.</param>
+        <param index="4" label="GCS Sysid">System ID of GCS requesting control. For a range of GCS in control, this the minimum id (and the sender system ID may be anywhere in the range).</param>
+        <param index="5" label="GCS Sysid (upper range)">Upper range of controlling GCS system IDs. 0 for single-GCS control. If non-zero the sender system ID may be anywhere in the range).</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="5005" name="MAV_CMD_NAV_FENCE_HOME_CIRCLE_INCLUSION" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Circular fence area centered on home. The vehicle must stay inside this area. If home is moved, the fence moves.</description>
+        <param index="1" label="Radius" units="m">Radius.</param>
+        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group. Ignored when sent as a command.</param>
+      </entry>
     </enum>
     <enum name="GPS_SYSTEM_ERROR_FLAGS" bitmask="true">
       <description>Flags indicating errors in a GPS receiver.</description>


### PR DESCRIPTION
This is a PR to discuss implementation of multi-operator control.

This message has [already been merged](https://github.com/mavlink/mavlink/pull/2158) in mavlink/mavlink/master

There was a [stab at implementing the message](https://github.com/ArduPilot/ardupilot/pull/29252).

I'm not sure the messages are fit for purpose.

## Key points:
 - there are some resources which should only ever be accessed by one mavlink node at a time:
   - only one GCS should be able to use streamed position control commands at a time (e.g. `SET_POSITION_TARGET_GLOBAL_INT`)
     - this doesn't necessarily need to be part of this permissions system, it could be done with timeout
   - only one GCS should be able to stream in `FOLLOW_TARGET`
     - this doesn't necessarily need to be part of this permissions system, it could be done with timeout
   - only one GCS should be able to stream in `RC_CHANNEL_OVERRIDES` / `MANUAL_CONTROL`
     - this doesn't necessarily need to be part of this permissions system, it could be done with timeout
   - only one GCS should be able to set streamrates / per-message-rates on a link
     - this doesn't necessarily need to be part of this permissions system, it could be done with timeout
       - this could still lead to fighting amongst GCSs as a valid implementation is to watch the rate and only adjust it if you  don't like what you see; two GCSs doing this can oscillate [control](url)
  - armed/disarmed behavioural changes
    - Peter and tridge have been involved in operations where we wanted to ignore *all* input from non-blessed GCSs.
     - a clean story for the operators to know that devices just "listening in" (to provide observability on the operation) can't affect the vehicle while it is armed
  - need some way to make sure someone always has access to the vehicle
  - tridge suggested a simple "steal control" which always works
  - Leonard wants the primary pilot to always be able to assume control (RC input in this case)
  - Leonard wants an absolute chain of custody for the control of the aircraft regardless of how the thing is being controlled
    - e.g. even guided-mode commands
  - companion computers on the aircraft doing pos/vel commands
    - how do you stop the crazy cc from doing what it is doing?
    - does the CC need to request control for SET_ATTITUDE_TARGET?
    - operator still needs to take control back!

## Some user stories

1. Canberra BVLOS operations (@peterbarker @tridge @MichelleRos )
  - we typically run two laptops which must always be able to command the vehicle
    - only one of those laptops should be able to command the vehicle via RC_CHANNEL_OVERRIDES or MANUAL_CONTROL at a time
      - only one of these laptops should be able to manipulate the streamrates on the vehicle
  - a H16 hand control unit also acts as a GCS. 
    - This unit should be able to download parameters
    - this unit should *not* be able to manipulate fences, rally points and esp. not manipulate the mission
    - this unit should be allowed to set streamrates on its link to the vehicle


2. FreeSpace Operations shipops operations  (@lthall)
  - many RPi-based GCS all of which may want to control the vehicle via RC
    - all of them share the same GCS link to the flight controller (Silvus network)
    - all of them should be able to take control of RC for the vehicle
    - they should not necessarily be allowed to change the mission/rally/fence!
    - parameter sets are not necessarily allowed!
  - other GCSs may be used to set up missions etc.
  - precision landing relies on FOLLOW_TARGET coming from another mavlink node

3. Freespace Operations multi-GCS multi-vehicle craning operations
 - FOLLOW_TARGET used and should only be used from one vehicle
 - otherwise much as above without the precision landing
 - need to be very careful that users don't take control of vehicles accidentally!
 - 