### PR TITLE
 Move MAV_CMD_GUIDED_CHANGE_HEADING to common.xml

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -20,11 +20,7 @@
       <entry value="16777215" name="ACCELCAL_VEHICLE_POS_SUCCESS"/>
       <entry value="16777216" name="ACCELCAL_VEHICLE_POS_FAILED"/>
     </enum>
-    <enum name="HEADING_TYPE">
-      <entry value="0" name="HEADING_TYPE_COURSE_OVER_GROUND"/>
-      <entry value="1" name="HEADING_TYPE_HEADING"/>
-      <entry value="2" name="HEADING_TYPE_DEFAULT"/>
-    </enum>
+    <!-- HEADING_TYPE moved to common.xml -->
     <!-- ardupilot specific MAV_CMD_* commands -->
     <enum name="MAV_CMD">
       <!-- 200 to 214 used by common.xml -->
@@ -321,16 +317,7 @@
         <param index="6">Empty</param>
         <param index="7" label="target alt" units="m">Target Altitude</param>
       </entry>
-      <entry value="43002" name="MAV_CMD_GUIDED_CHANGE_HEADING" hasLocation="false" isDestination="false">
-        <description>Change to target heading at a given rate, overriding previous heading/s. This slews the vehicle at a controllable rate between it's previous heading and the new one. (affects GUIDED only. Exiting GUIDED returns aircraft to normal behaviour defined elsewhere. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
-        <param index="1" label="heading type" enum="HEADING_TYPE">course-over-ground or raw vehicle heading.</param>
-        <param index="2" label="heading target" units="deg" minValue="0" maxValue="359.99">Target heading.</param>
-        <param index="3" label="heading rate-of-change" units="m/s/s">Maximum centripetal accelearation, ie rate of change,  toward new heading.</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
+      <!-- 43002 MAV_CMD_GUIDED_CHANGE_HEADING moved to common.xml -->
       <entry value="43005" name="MAV_CMD_SET_HAGL" hasLocation="false" isDestination="false">
         <description>Provide a value for height above ground level. This can be used for things like fixed wing and VTOL landing.</description>
         <param index="1" label="hagl" units="m">Height above ground level.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2461,6 +2461,16 @@
         <param index="6">Empty.</param>
         <param index="7">Empty.</param>
       </entry>
+      <entry value="43002" name="MAV_CMD_GUIDED_CHANGE_HEADING" hasLocation="false" isDestination="false">
+        <description>Change to target heading at a given rate, overriding previous heading/s. This slews the vehicle at a controllable rate between it's previous heading and the new one. (affects GUIDED only. Exiting GUIDED returns aircraft to normal behaviour defined elsewhere. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
+        <param index="1" label="heading type" enum="HEADING_TYPE">course-over-ground or raw vehicle heading.</param>
+        <param index="2" label="heading target" units="deg" minValue="0" maxValue="359.99">Target heading.</param>
+        <param index="3" label="heading rate-of-change" units="m/s/s">Maximum centripetal accelearation, ie rate of change,  toward new heading.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <!-- from ardupilotmega.xml (hence ID is in that range) -->
       <entry value="43003" name="MAV_CMD_EXTERNAL_POSITION_ESTIMATE" hasLocation="true" isDestination="false">
         <description>Provide an external position estimate for use when dead-reckoning. This is meant to be used for occasional position resets that may be provided by a external system such as a remote pilot using landmarks over a video link.</description>
@@ -3446,6 +3456,11 @@
       <entry value="3" name="SPEED_TYPE_DESCENT_SPEED">
         <description>Descent speed</description>
       </entry>
+    </enum>
+    <enum name="HEADING_TYPE">
+      <entry value="0" name="HEADING_TYPE_COURSE_OVER_GROUND"/>
+      <entry value="1" name="HEADING_TYPE_HEADING"/>
+      <entry value="2" name="HEADING_TYPE_DEFAULT"/>
     </enum>
     <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
     <enum name="ESTIMATOR_STATUS_FLAGS" bitmask="true">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2462,14 +2462,10 @@
         <param index="7">Empty.</param>
       </entry>
       <entry value="43002" name="MAV_CMD_GUIDED_CHANGE_HEADING" hasLocation="false" isDestination="false">
-        <description>Change to target heading at a given rate, overriding previous heading/s. This slews the vehicle at a controllable rate between it's previous heading and the new one. (affects GUIDED only. Exiting GUIDED returns aircraft to normal behaviour defined elsewhere. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
-        <param index="1" label="heading type" enum="HEADING_TYPE">course-over-ground or raw vehicle heading.</param>
-        <param index="2" label="heading target" units="deg" minValue="0" maxValue="359.99">Target heading.</param>
-        <param index="3" label="heading rate-of-change" units="m/s/s">Maximum centripetal accelearation, ie rate of change,  toward new heading.</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
+        <description>Change to target direction at a given rate, overriding previous heading/s. This slews the vehicle at a controllable rate between its previous heading and the new one.</description>
+        <param index="1" label="Heading Type" enum="HEADING_TYPE">Course-over-ground or raw vehicle heading.</param>
+        <param index="2" label="Heading Target" units="deg" minValue="0" maxValue="359.99">Target heading.</param>
+        <param index="3" label="Heading Rate of Change" units="deg/s">Maximum centripetal acceleration, i.e. rate of change toward new heading.</param>
       </entry>
       <!-- from ardupilotmega.xml (hence ID is in that range) -->
       <entry value="43003" name="MAV_CMD_EXTERNAL_POSITION_ESTIMATE" hasLocation="true" isDestination="false">
@@ -3458,9 +3454,16 @@
       </entry>
     </enum>
     <enum name="HEADING_TYPE">
-      <entry value="0" name="HEADING_TYPE_COURSE_OVER_GROUND"/>
-      <entry value="1" name="HEADING_TYPE_HEADING"/>
-      <entry value="2" name="HEADING_TYPE_DEFAULT"/>
+      <description>Heading setpoint types used in MAV_CMD_GUIDED_CHANGE_HEADING</description>
+      <entry value="0" name="HEADING_TYPE_COURSE_OVER_GROUND">
+        <description>Course over ground.</description>
+      </entry>
+      <entry value="1" name="HEADING_TYPE_HEADING">
+        <description>Raw vehicle heading.</description>
+      </entry>
+      <entry value="2" name="HEADING_TYPE_DEFAULT">
+        <description>Default heading.</description>
+      </entry>
     </enum>
     <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
     <enum name="ESTIMATOR_STATUS_FLAGS" bitmask="true">


### PR DESCRIPTION
This moves MAV_CMD_GUIDED_CHANGE_HEADING  to common.xml.

The change has been done in two commits to make it easier to review. The first commit moves the command and enum as-is.

The second commit contains updates to make it usable in a common context:
- Description - removes just the " (affects GUIDED only ..." bit at the end.
- Capitalises labels.
- Removes the empty params.
- Adds descriptions for the HEADING_TYPE enum

This is matches https://github.com/mavlink/mavlink/pull/2493