### PR TITLE
MOve MAV_CMD_GUIDED_CHANGE_{SPEED/ALTITUDE} to common.xml

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -297,26 +297,8 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="43000" name="MAV_CMD_GUIDED_CHANGE_SPEED" hasLocation="false" isDestination="false">
-        <description>Change flight speed at a given rate. This slews the vehicle at a controllable rate between it's previous speed and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
-        <param index="1" label="speed type" enum="SPEED_TYPE">Airspeed or groundspeed.</param>
-        <param index="2" label="speed target" units="m/s">Target Speed</param>
-        <param index="3" label="speed rate-of-change" units="m/s/s">Acceleration rate, 0 to take effect instantly</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="43001" name="MAV_CMD_GUIDED_CHANGE_ALTITUDE" hasLocation="false" isDestination="false">
-        <description>Change target altitude at a given rate. This slews the vehicle at a controllable rate between it's previous altitude and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3" label="alt rate-of-change" units="m/s" minValue="0">Rate of change, toward new altitude. 0 for maximum rate change. Positive numbers only, as negative numbers will not converge on the new target alt.</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7" label="target alt" units="m">Target Altitude</param>
-      </entry>
+      <!-- 43000 MAV_CMD_GUIDED_CHANGE_SPEED moved to common.xml -->
+      <!-- 43001 MAV_CMD_GUIDED_CHANGE_ALTITUDE moved to common.xml -->
       <!-- 43002 MAV_CMD_GUIDED_CHANGE_HEADING moved to common.xml -->
       <entry value="43005" name="MAV_CMD_SET_HAGL" hasLocation="false" isDestination="false">
         <description>Provide a value for height above ground level. This can be used for things like fixed wing and VTOL landing.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2465,6 +2465,27 @@
         <param index="6">Empty.</param>
         <param index="7">Empty.</param>
       </entry>
+      <!-- from ardupilotmega.xml (hence ID is in that range) -->
+      <entry value="43000" name="MAV_CMD_GUIDED_CHANGE_SPEED" hasLocation="false" isDestination="false">
+        <description>Change flight speed at a given rate. This slews the vehicle at a controllable rate between it's previous speed and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
+        <param index="1" label="speed type" enum="SPEED_TYPE">Airspeed or groundspeed.</param>
+        <param index="2" label="speed target" units="m/s">Target Speed</param>
+        <param index="3" label="speed rate-of-change" units="m/s/s">Acceleration rate, 0 to take effect instantly</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="43001" name="MAV_CMD_GUIDED_CHANGE_ALTITUDE" hasLocation="false" isDestination="false">
+        <description>Change target altitude at a given rate. This slews the vehicle at a controllable rate between it's previous altitude and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3" label="alt rate-of-change" units="m/s" minValue="0">Rate of change, toward new altitude. 0 for maximum rate change. Positive numbers only, as negative numbers will not converge on the new target alt.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7" label="target alt" units="m">Target Altitude</param>
+      </entry>
       <entry value="43002" name="MAV_CMD_GUIDED_CHANGE_HEADING" hasLocation="false" isDestination="false">
         <description>Change to target direction at a given rate, overriding previous heading/s. This slews the vehicle at a controllable rate between its previous heading and the new one.</description>
         <param index="1" label="Heading Type" enum="HEADING_TYPE">Course-over-ground or raw vehicle heading.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2467,23 +2467,14 @@
       </entry>
       <!-- from ardupilotmega.xml (hence ID is in that range) -->
       <entry value="43000" name="MAV_CMD_GUIDED_CHANGE_SPEED" hasLocation="false" isDestination="false">
-        <description>Change flight speed at a given rate. This slews the vehicle at a controllable rate between it's previous speed and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
+        <description>Change flight speed at a given rate. This slews the vehicle at a controllable rate between it's previous speed and the new one.</description>
         <param index="1" label="speed type" enum="SPEED_TYPE">Airspeed or groundspeed.</param>
         <param index="2" label="speed target" units="m/s">Target Speed</param>
         <param index="3" label="speed rate-of-change" units="m/s/s">Acceleration rate, 0 to take effect instantly</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
       </entry>
       <entry value="43001" name="MAV_CMD_GUIDED_CHANGE_ALTITUDE" hasLocation="false" isDestination="false">
-        <description>Change target altitude at a given rate. This slews the vehicle at a controllable rate between it's previous altitude and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
+        <description>Change target altitude at a given rate. This slews the vehicle at a controllable rate between it's previous altitude and the new one.</description>
         <param index="3" label="alt rate-of-change" units="m/s" minValue="0">Rate of change, toward new altitude. 0 for maximum rate change. Positive numbers only, as negative numbers will not converge on the new target alt.</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
         <param index="7" label="target alt" units="m">Target Altitude</param>
       </entry>
       <entry value="43002" name="MAV_CMD_GUIDED_CHANGE_HEADING" hasLocation="false" isDestination="false">


### PR DESCRIPTION
We moved `MAV_CMD_GUIDED_CHANGE_HEADING` from ardupilotmega.xml to common.xml last week. IN https://github.com/mavlink/mavlink/pull/2493#issuecomment-4528154628 @davidbuzz pointed out that this is normally used with `MAV_CMD_GUIDED_CHANGE_SPEED` and `MAV_CMD_GUIDED_CHANGE_ALTITUDE`.

This PR is to explore the appetite of ArduPilot for moving the commands - which makes sense as it groups like with like.
Note, 2 commits - the first is a direct copy, and the second is minor modifications for mavlink/mavlink.

@davidbuzz @rmackay9 @peterbarker This was discussed in the MAV call. We're not opposed, but we wanted to make sure this seems reasonable to you. If so, I will create a companion PR in mavlink/mavlink and get buy-in there too.

FYI Under the way we are running common.xml at the moment something can go into common.xml if it is supported in two stakeholder stacks, or by one stakeholder stack and the other either plans to take it, or accepts that it is "good" but doesn't need it right now. We don't accept things otherwise - such as "not considered a good design that can be standardised". We're slowing moving things that are truly standard to standard.xml. 

