### PR TITLE
add union param types for int32/uint32 

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2776,6 +2776,12 @@
       <entry value="5" name="MAV_PARAM_ERROR_READ_ONLY">
         <description>Parameter is read-only</description>
       </entry>
+      <entry value="6" name="MAV_PARAM_ERROR_TYPE_UNSUPPORTED">
+        <description>Parameter data type (MAV_PARAM_TYPE) is not supported by flight stack (at all)</description>
+      </entry>
+      <entry value="7" name="MAV_PARAM_ERROR_TYPE_MISMATCH">
+        <description>Parameter type does not match expected type</description>
+      </entry>
     </enum>
     <enum name="MAV_PARAM_EXT_TYPE">
       <description>Specifies the datatype of a MAVLink extended parameter.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2747,6 +2747,12 @@
       <entry value="10" name="MAV_PARAM_TYPE_REAL64">
         <description>64-bit floating-point</description>
       </entry>
+      <entry value="11" name="MAV_PARAM_TYPE_UNION_INT32">
+        <description>32-bit signed integer carried byte-wise in the param_value field.</description>
+      </entry>
+      <entry value="12" name="MAV_PARAM_TYPE_UNION_UINT32">
+        <description>32-bit unsigned integer carried byte-wise in the param_value field.</description>
+      </entry>
     </enum>
     <enum name="MAV_PARAM_ERROR">
       <wip/>

--- a/message_definitions/v1.0/standard.xml
+++ b/message_definitions/v1.0/standard.xml
@@ -90,6 +90,9 @@
         <wip/>
         <description>Autopilot has a connected gripper. MAVLink Grippers would set MAV_TYPE_GRIPPER instead.</description>
       </entry>
+      <entry value="2097152" name="MAV_PROTOCOL_CAPABILITY_PARAM_UNION_INT32">
+        <description>Component accepts PARAM_SET and emits PARAM_VALUE with the byte-wise MAV_PARAM_TYPE_UNION_INT32/MAV_PARAM_TYPE_UNION_UINT32 types for lossless transport of 32-bit integer parameter values that are not exactly representable as a 32-bit float. Only meaningful in combination with MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST: byte-wise encoded systems are already lossless. Ground stations should should send the union types to a component that does not advertise this capability.</description>
+      </entry>
     </enum>
     <enum name="FIRMWARE_VERSION_TYPE">
       <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>


### PR DESCRIPTION
This implements a method of allowing PARAM_VALUE and PARAM_SET to support uint32/int32 on ArduPilot while maintaining backwards compatibility with existing ground stations.
