### PR TITLE
common.xml: rename MAV_WINCH_STATUS_CLUTCH_ENGAGED to MAV_WINCH_STATUS_CLUTCH_DISENGAGED

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4703,8 +4703,8 @@
       <entry value="4" name="MAV_WINCH_STATUS_MOVING">
         <description>Winch motor is moving</description>
       </entry>
-      <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_ENGAGED">
-        <description>Winch clutch is engaged allowing motor to move freely</description>
+      <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_DISENGAGED">
+        <description>Winch clutch is disengaged. The motor is moving freely and not driving the winch.</description>
       </entry>
     </enum>
     <enum name="MAG_CAL_STATUS">


### PR DESCRIPTION
The description is obviously at odds with what people are expecting engaged/disengaged to mean.  Change the name, not the meaning.